### PR TITLE
revapi-standalone: fix NPE

### DIFF
--- a/revapi-standalone/src/main/java/org/revapi/standalone/Main.java
+++ b/revapi-standalone/src/main/java/org/revapi/standalone/Main.java
@@ -55,6 +55,8 @@ import org.jboss.forge.furnace.util.Addons;
 import gnu.getopt.Getopt;
 import gnu.getopt.LongOpt;
 
+import static java.util.Collections.emptyList;
+
 /**
  * @author Lukas Krejci
  * @since 0.1
@@ -239,7 +241,7 @@ public final class Main {
             oldSupplementaryArchives = res.supplementaryArchives;
         } else {
             oldArchives = convertPaths(oldArchivePaths, "Old API files");
-            oldSupplementaryArchives = oldSupplementaryArchivePaths == null ? null :
+            oldSupplementaryArchives = oldSupplementaryArchivePaths == null ? emptyList() :
                 convertPaths(oldSupplementaryArchivePaths, "Old API supplementary files");
         }
 
@@ -249,7 +251,7 @@ public final class Main {
             newSupplementaryArchives = res.supplementaryArchives;
         } else {
             newArchives = convertPaths(newArchivePaths, "New API files");
-            newSupplementaryArchives = newSupplementaryArchivePaths == null ? null :
+            newSupplementaryArchives = newSupplementaryArchivePaths == null ? emptyList() :
                 convertPaths(newSupplementaryArchivePaths, "New API supplementary files");
         }
 


### PR DESCRIPTION
```
revapi.sh -e org.revapi:revapi-java:0.3.1,org.revapi:revapi-reporting-text:0.3.1 -o rut-0.10.jar -n rut-0.10.jar
SLF4J: The following loggers will not work because they were created
SLF4J: during the default configuration phase of the underlying logging system.
SLF4J: See also http://www.slf4j.org/codes.html#substituteLogger
SLF4J: org.eclipse.aether.internal.impl.DefaultRepositorySystem
SLF4J: org.apache.maven.repository.internal.DefaultVersionResolver
SLF4J: org.eclipse.aether.internal.impl.DefaultMetadataResolver
SLF4J: org.eclipse.aether.internal.impl.DefaultRepositoryEventDispatcher
SLF4J: org.eclipse.aether.internal.impl.DefaultUpdateCheckManager
SLF4J: org.eclipse.aether.internal.impl.DefaultUpdatePolicyAnalyzer
SLF4J: org.eclipse.aether.internal.impl.DefaultRepositoryConnectorProvider
SLF4J: org.eclipse.aether.connector.wagon.WagonRepositoryConnector
SLF4J: org.eclipse.aether.internal.impl.DefaultRemoteRepositoryManager
SLF4J: org.eclipse.aether.internal.impl.DefaultOfflineController
SLF4J: org.apache.maven.repository.internal.DefaultVersionRangeResolver
SLF4J: org.eclipse.aether.internal.impl.DefaultArtifactResolver
SLF4J: org.apache.maven.repository.internal.DefaultArtifactDescriptorReader
SLF4J: org.eclipse.aether.internal.impl.DefaultDependencyCollector
SLF4J: org.eclipse.aether.internal.impl.DefaultInstaller
SLF4J: org.eclipse.aether.internal.impl.DefaultDeployer
SLF4J: org.eclipse.aether.internal.impl.DefaultLocalRepositoryProvider
SLF4J: org.eclipse.aether.internal.impl.SimpleLocalRepositoryManager
SLF4J: org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManager
java.lang.NullPointerException
	at org.revapi.API$Builder.addSupportArchives(API.java:83)
	at org.revapi.API$Builder.supportedBy(API.java:70)
	at org.revapi.standalone.Main.run(Main.java:303)
	at org.revapi.standalone.Main.main(Main.java:257)
```