### PR TITLE
Fix Revapi invocation example

### DIFF
--- a/revapi-site/src/site/asciidoc/getting-started.adoc
+++ b/revapi-site/src/site/asciidoc/getting-started.adoc
@@ -33,7 +33,7 @@ and you will be presented with the usual usage information.
 An invocation of Revapi could look like this:
 
 ----
-./revapi.sh -extensions=org.revapi:revapi-java:{version},org.revapi:revapi-text-reporter:{version} \
+./revapi.sh --extensions=org.revapi:revapi-java:{version},org.revapi:revapi-reporting-text:{version} \
    --old=my-lib-0.1.0.jar --new=my-lib-0.2.0.jar -D revapi.reporter.text.minSeverity=BREAKING
 ----
 


### PR DESCRIPTION
The current example of Revapi invocation leads to:

```
java.lang.RuntimeException: org.eclipse.aether.resolution.DependencyResolutionException: Could not find artifact xtensions=org.revapi:revapi-java:jar:0.5.2 in central (http://repo1.maven.org/maven2)
	at org.revapi.standalone.ExtensionResolver.resolveResources(ExtensionResolver.java:146)
	at org.revapi.standalone.LazyAddonInfo.resolveResources(LazyAddonInfo.java:69)
	at org.revapi.standalone.LazyAddonInfo.getResources(LazyAddonInfo.java:28)
	at org.jboss.forge.furnace.manager.impl.request.DeployRequestImpl.deploy(DeployRequestImpl.java:59)
	at org.jboss.forge.furnace.manager.impl.request.DeployRequestImpl$1.call(DeployRequestImpl.java:49)
	at org.jboss.forge.furnace.impl.LockManagerImpl.performLocked(LockManagerImpl.java:48)
	at org.jboss.forge.furnace.manager.impl.request.DeployRequestImpl.execute(DeployRequestImpl.java:44)
	at org.jboss.forge.furnace.manager.impl.request.AbstractAddonActionRequest.perform(AbstractAddonActionRequest.java:57)
	at org.jboss.forge.furnace.manager.impl.request.InstallRequestImpl.perform(InstallRequestImpl.java:39)
	at org.revapi.standalone.Main.run(Main.java:291)
	at org.revapi.standalone.Main.main(Main.java:259)

```

or to:
```
java.lang.RuntimeException: org.eclipse.aether.resolution.DependencyResolutionException: Could not find artifact org.revapi:revapi-text-reporter:jar:0.3.4 in central (http://repo1.maven.org/maven2)
	at org.revapi.standalone.ExtensionResolver.resolveResources(ExtensionResolver.java:146)
	at org.revapi.standalone.LazyAddonInfo.resolveResources(LazyAddonInfo.java:69)
	at org.revapi.standalone.LazyAddonInfo.getResources(LazyAddonInfo.java:28)
	at org.jboss.forge.furnace.manager.impl.request.DeployRequestImpl.deploy(DeployRequestImpl.java:59)
	at org.jboss.forge.furnace.manager.impl.request.DeployRequestImpl$1.call(DeployRequestImpl.java:49)
	at org.jboss.forge.furnace.impl.LockManagerImpl.performLocked(LockManagerImpl.java:48)
	at org.jboss.forge.furnace.manager.impl.request.DeployRequestImpl.execute(DeployRequestImpl.java:44)
	at org.jboss.forge.furnace.manager.impl.request.AbstractAddonActionRequest.perform(AbstractAddonActionRequest.java:57)
	at org.jboss.forge.furnace.manager.impl.request.InstallRequestImpl.perform(InstallRequestImpl.java:39)
	at org.revapi.standalone.Main.run(Main.java:291)
	at org.revapi.standalone.Main.main(Main.java:259)

```