### PR TITLE
Fix referenced parent poms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ cache:
   directories:
     - $HOME/.m2
 
+#delete all our historic build artifacts so that the stale versions do
+#not pollute the build. 
+before_script:
+  - rm -Rf $HOME/.m2/repository/org/revapi
+
 script:
   - mvn clean verify --batch-mode --fail-at-end
 

--- a/revapi-ant-task/pom.xml
+++ b/revapi-ant-task/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.revapi</groupId>
         <artifactId>revapi-build</artifactId>
-        <version>27-SNAPSHOT</version>
+        <version>29-SNAPSHOT</version>
         <relativePath>../revapi-build</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/revapi-maven-utils/pom.xml
+++ b/revapi-maven-utils/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.revapi</groupId>
         <artifactId>revapi-build</artifactId>
-        <version>27-SNAPSHOT</version>
+        <version>29-SNAPSHOT</version>
         <relativePath>../revapi-build</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/revapi-reporter-text/pom.xml
+++ b/revapi-reporter-text/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.revapi</groupId>
         <artifactId>revapi-build</artifactId>
-        <version>27-SNAPSHOT</version>
+        <version>29-SNAPSHOT</version>
         <relativePath>../revapi-build</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/revapi-reporter-text/pom.xml
+++ b/revapi-reporter-text/pom.xml
@@ -32,7 +32,7 @@
     <url>${web.url}/modules/${project.artifactId}</url>
     
     <artifactId>revapi-reporter-text</artifactId>
-    <version>0.6.2-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/revapi-site/pom.xml
+++ b/revapi-site/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.revapi</groupId>
     <artifactId>revapi-build</artifactId>
-    <version>27-SNAPSHOT</version>
+    <version>29-SNAPSHOT</version>
     <relativePath>../revapi-build</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/revapi-standalone/pom.xml
+++ b/revapi-standalone/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.revapi</groupId>
         <artifactId>revapi-build</artifactId>
-        <version>27-SNAPSHOT</version>
+        <version>29-SNAPSHOT</version>
         <relativePath>../revapi-build</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Few projects referenced revapi-build with version 27-SNAPSHOT where
current version of this pom is 29-SNAPSHOT.

This was working on CI (probably) because there were cached revapi-build-27-SNAPSHOT there.