### PR TITLE
Don't allow arrays to have text nodes in XML to JSON converter

### DIFF
--- a/revapi/src/main/java/org/revapi/configuration/XmlToJson.java
+++ b/revapi/src/main/java/org/revapi/configuration/XmlToJson.java
@@ -224,6 +224,9 @@ public final class XmlToJson<Xml> {
             throw new IllegalArgumentException(
                     "No schema found for items of a list. Cannot continue with XML-to-JSON conversion.");
         }
+        if (getValue.apply( configuration ) != null) {
+            throw new IllegalArgumentException("Array is not allowed to have a text node");
+        }
         ModelNode list = new ModelNode();
         list.setEmptyList();
         for (Xml childConfig : getChildren.apply(configuration)) {

--- a/revapi/src/test/java/org/revapi/configuration/XmlToJsonTest.java
+++ b/revapi/src/test/java/org/revapi/configuration/XmlToJsonTest.java
@@ -136,6 +136,14 @@ public class XmlToJsonTest {
         Assert.assertEquals(2L, config.asList().get(1).asLong());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testArrayConversion_invalid() throws Exception {
+        XmlToJson<Node> converter = converter("list", "{\"type\": \"array\", \"items\": {\"type\": \"integer\"}}");
+        Node xml = xml("<config><list>text</list></config>");
+
+        converter.convert(xml).get(0).get("configuration");
+    }
+
     @Test
     public void testObjectConversion() throws Exception {
         XmlToJson<Node> converter = converter("ext", "{\"type\": \"object\", " +


### PR DESCRIPTION
I found a bug while trying to configure the maven plugin:
```xml
<analysisConfiguration>
  <revapi.java>
    <reportUsesFor>all-differences</reportUsesFor>
  </revapi.java>
</analysisConfiguration>
```
JSON schema states is has to be `oneOf` array or string. The above config matches both a string and an empty array, and the configuration validation fails.

This fix does not allow the array type to have a text node present.