### PR TITLE
revapi-maven-plugin: Make aggregator reporter rely on user-configurable properties, instead of using hardcoded values

### DIFF
--- a/revapi-maven-plugin/src/main/java/org/revapi/maven/ReportAggregateMojo.java
+++ b/revapi-maven-plugin/src/main/java/org/revapi/maven/ReportAggregateMojo.java
@@ -261,23 +261,18 @@ public class ReportAggregateMojo extends ReportMojo {
             return null;
         }
 
-        boolean failOnMissingConfigurationFiles = false;
-        boolean failOnMissingArchives = false;
-        boolean failOnMissingSupportArchives = false;
-        boolean alwaysUpdate = true;
-        boolean resolveDependencies = true;
         String versionRegex = getValueOfChild(runConfig, "versionFormat");
 
         AnalyzerBuilder bld = AnalyzerBuilder.forArtifacts(oldArtifacts, newArtifacts)
-                .withAlwaysCheckForReleasedVersion(alwaysUpdate)
+                .withAlwaysCheckForReleasedVersion(this.alwaysCheckForReleaseVersion)
                 .withAnalysisConfiguration(this.analysisConfiguration)
                 .withAnalysisConfigurationFiles(this.analysisConfigurationFiles)
-                .withCheckDependencies(resolveDependencies)
-                .withResolveProvidedDependencies(resolveProvidedDependencies)
+                .withCheckDependencies(this.checkDependencies)
+                .withResolveProvidedDependencies(this.resolveProvidedDependencies)
                 .withDisallowedExtensions(disallowedExtensions)
-                .withFailOnMissingConfigurationFiles(failOnMissingConfigurationFiles)
-                .withFailOnUnresolvedArtifacts(failOnMissingArchives)
-                .withFailOnUnresolvedDependencies(failOnMissingSupportArchives)
+                .withFailOnMissingConfigurationFiles(this.failOnMissingConfigurationFiles)
+                .withFailOnUnresolvedArtifacts(this.failOnUnresolvedArtifacts)
+                .withFailOnUnresolvedDependencies(this.failOnUnresolvedDependencies)
                 .withLocale(locale)
                 .withLog(getLog())
                 .withProject(project)


### PR DESCRIPTION
The aggregator reporter was using hardcoded values for the
following properties:

 * failOnMissingConfigurationFiles (false)
 * failOnMissingArchives (false)
 * failOnMissingSupportArchives (false)
 * alwaysUpdate (true)
 * resolveDependencies (true)

This commit updates the plugin to use the user-defined values, while
keeping the same defaults as the previous hardcoded ones.