### PR TITLE
Fix order of java.annotation.attributeValueChanged description 2nd time

### DIFF
--- a/revapi-java-spi/src/main/resources/org/revapi/java/checks/descriptions.properties
+++ b/revapi-java-spi/src/main/resources/org/revapi/java/checks/descriptions.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2017 Lukas Krejci
+# Copyright 2014-2018 Lukas Krejci
 # and other contributors as indicated by the @author tags.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/revapi-java-spi/src/main/resources/org/revapi/java/checks/descriptions.properties
+++ b/revapi-java-spi/src/main/resources/org/revapi/java/checks/descriptions.properties
@@ -48,7 +48,7 @@ capacity in the API.
 java.annotation.added=Element newly annotated with ''{0}''.
 java.annotation.attributeAdded=Attribute ''{0}'' of annotation ''{1}'' is now explicitly set.
 java.annotation.attributeRemoved=Attribute ''{0}'' of annotation ''{1}'' is no longer explicitly set.
-java.annotation.attributeValueChanged=Attribute ''{0}'' of annotation ''{3}'' changed value from ''{1}'' to ''{2}''.
+java.annotation.attributeValueChanged=Attribute ''{2}'' of annotation ''{0}'' changed value from ''{3}'' to ''{4}''.
 java.annotation.removed=Element no longer annotated with ''{0}''.
 java.annotation.noLongerInherited=Annotation type is no longer inherited.
 java.annotation.nowInherited=Annotation type is now inherited.


### PR DESCRIPTION
Hi, @metlos,

as in #64, there has been a wrong order of parameters. In this commit: https://github.com/revapi/revapi/commit/8e13254682a1b79ac49b10f8cecb2401725c522e#diff-e0e1aed5ad3e5d4897d24db60e6030b8R75 you prepended annotationType and annotation so now the message is formatted like: Attribute $annotationType (index 0) of annotation $oldValue (index 3) changed value from $annotation (index 1) to $oldvalue (index 2). In addition, annotationType is implicitly added with elementKind here: https://github.com/revapi/revapi/blob/master/revapi-java-spi/src/main/java/org/revapi/java/spi/Code.java#L210 So do you need to add it in AttributeValueChanged.java?

I have fixed it by changing the order of parameters in the message, but we can agree on a different solution.

Thanks,

Marian
