### PR TITLE
Return a map from Code#attachmentsFor

### DIFF
--- a/revapi-java-spi/src/main/java/org/revapi/java/spi/CheckBase.java
+++ b/revapi-java-spi/src/main/java/org/revapi/java/spi/CheckBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Lukas Krejci
+ * Copyright 2014-2018 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ package org.revapi.java.spi;
 import java.io.Reader;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import javax.annotation.Nonnull;
@@ -164,15 +165,15 @@ public abstract class CheckBase implements Check {
     private AnalysisContext analysisContext;
 
     @Nonnull
-    protected Difference createDifference(@Nonnull Code code, String[] attachments) {
+    protected Difference createDifference(@Nonnull Code code, LinkedHashMap<String, String> attachments) {
         return code.createDifference(getAnalysisContext().getLocale(), attachments);
     }
 
     @Nonnull
     protected Difference createDifferenceWithExplicitParams(@Nonnull Code code,
-                                                            String[] attachments,
+                                                            LinkedHashMap<String, String> attachments,
                                                             String... params) {
-            return code.createDifferenceWithExplicitParams(getAnalysisContext().getLocale(), attachments, params);
+            return code.createDifference(getAnalysisContext().getLocale(), attachments, params);
     }
 
     @Nonnull

--- a/revapi-java-spi/src/main/java/org/revapi/java/spi/Code.java
+++ b/revapi-java-spi/src/main/java/org/revapi/java/spi/Code.java
@@ -221,7 +221,6 @@ public enum Code {
             ret.put("package", getPackageName(type));
             ret.put("classQualifiedName", getClassQualifiedName(type));
             ret.put("classSimpleName", getClassSimpleName(type));
-            ret.put("elementType", null);
         } else if (representative instanceof JavaMethodElement) {
             //package, classSimpleName, methodName
             JavaMethodElement method = representative.as(JavaMethodElement.class);

--- a/revapi-java/src/main/java/org/revapi/java/checks/classes/Added.java
+++ b/revapi-java/src/main/java/org/revapi/java/checks/classes/Added.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Lukas Krejci
+ * Copyright 2014-2018 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@ package org.revapi.java.checks.classes;
 
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import javax.lang.model.element.TypeElement;
@@ -39,7 +40,7 @@ public final class Added extends CheckBase {
             TypeElement typeInOld = getOldTypeEnvironment().getElementUtils()
                     .getTypeElement(types.newElement.getDeclaringElement().getQualifiedName());
 
-            String[] attachments = Code.attachmentsFor(types.oldElement, types.newElement);
+            LinkedHashMap<String, String> attachments = Code.attachmentsFor(types.oldElement, types.newElement);
             Difference difference = typeInOld == null
                     ? createDifference(Code.CLASS_ADDED, attachments)
                     : createDifference(Code.CLASS_EXTERNAL_CLASS_EXPOSED_IN_API, attachments);


### PR DESCRIPTION
Using an array made this code very difficult to edit and it was pretty straightforward to update things using a regex find + replace.

This change falls more into the not-totally-necessary category, so feel free to reject it.

@metlos 