### PR TITLE
Allow configuring what constitutes an external type

### DIFF
--- a/revapi-java/src/main/java/org/revapi/java/checks/classes/Added.java
+++ b/revapi-java/src/main/java/org/revapi/java/checks/classes/Added.java
@@ -24,6 +24,7 @@ import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 
+import javax.annotation.Nullable;
 import javax.lang.model.element.TypeElement;
 
 import org.revapi.Difference;
@@ -54,11 +55,13 @@ public final class Added extends InternalTypeWhitelistCheckBase {
         return null;
     }
 
+    @Nullable
     @Override
     public String getExtensionId() {
         return "externalClassExposedInAPI";
     }
 
+    @Nullable
     @Override
     public Reader getJSONSchema() {
         return new InputStreamReader(getClass().getResourceAsStream("/META-INF/externalClassExposedInAPI-config-schema.json"),

--- a/revapi-java/src/main/java/org/revapi/java/checks/classes/Added.java
+++ b/revapi-java/src/main/java/org/revapi/java/checks/classes/Added.java
@@ -16,6 +16,9 @@
  */
 package org.revapi.java.checks.classes;
 
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
@@ -24,15 +27,15 @@ import java.util.List;
 import javax.lang.model.element.TypeElement;
 
 import org.revapi.Difference;
-import org.revapi.java.spi.CheckBase;
 import org.revapi.java.spi.Code;
 import org.revapi.java.spi.JavaTypeElement;
 
 /**
  * @author Lukas Krejci
+ * @author James Phillpotts, ForgeRock AS.
  * @since 0.1
  */
-public final class Added extends CheckBase {
+public final class Added extends InternalTypeWhitelistCheckBase {
     @Override
     protected List<Difference> doEnd() {
         ActiveElements<JavaTypeElement> types = popIfActive();
@@ -41,14 +44,25 @@ public final class Added extends CheckBase {
                     .getTypeElement(types.newElement.getDeclaringElement().getQualifiedName());
 
             LinkedHashMap<String, String> attachments = Code.attachmentsFor(types.oldElement, types.newElement);
-            Difference difference = typeInOld == null
-                    ? createDifference(Code.CLASS_ADDED, attachments)
-                    : createDifference(Code.CLASS_EXTERNAL_CLASS_EXPOSED_IN_API, attachments);
-
-            return Collections.singletonList(difference);
+            if (typeInOld == null) {
+                return Collections.singletonList(createDifference(Code.CLASS_ADDED, attachments));
+            } else if (!isInternalType(typeInOld.toString())) {
+                return Collections.singletonList(createDifference(Code.CLASS_EXTERNAL_CLASS_EXPOSED_IN_API, attachments));
+            }
         }
 
         return null;
+    }
+
+    @Override
+    public String getExtensionId() {
+        return "externalClassExposedInAPI";
+    }
+
+    @Override
+    public Reader getJSONSchema() {
+        return new InputStreamReader(getClass().getResourceAsStream("/META-INF/externalClassExposedInAPI-config-schema.json"),
+                Charset.forName("UTF-8"));
     }
 
     @Override

--- a/revapi-java/src/main/java/org/revapi/java/checks/classes/InternalTypeWhitelistCheckBase.java
+++ b/revapi-java/src/main/java/org/revapi/java/checks/classes/InternalTypeWhitelistCheckBase.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Lukas Krejci
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.revapi.java.checks.classes;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nonnull;
+
+import org.jboss.dmr.ModelNode;
+import org.revapi.AnalysisContext;
+import org.revapi.java.spi.CheckBase;
+
+/**
+ * An extension of {@link CheckBase} that can be configured with a whitelist for identifying
+ * types that are considered internal even though they are not in the accessible source.
+ *
+ * @author James Phillpotts, ForgeRock AS.
+ */
+abstract class InternalTypeWhitelistCheckBase extends CheckBase {
+    private List<Predicate<String>> internalTypes;
+
+    @Override
+    public void initialize(@Nonnull AnalysisContext analysisContext) {
+        super.initialize(analysisContext);
+        ModelNode internalTypes = analysisContext.getConfiguration().get("internalTypes");
+        if (internalTypes.isDefined()) {
+            List<Predicate<String>> typePatterns = new ArrayList<>();
+            for (ModelNode pattern : internalTypes.asList()) {
+                typePatterns.add(Pattern.compile(pattern.asString()).asPredicate());
+            }
+            this.internalTypes = typePatterns;
+        } else {
+            this.internalTypes = new ArrayList<>();
+        }
+    }
+
+    /**
+     * Checks whether the provided type is an internal type from the whitelist.
+     *
+     * @param type The fully qualified type name.
+     * @return {@literal true} if the type is whitelisted.
+     */
+    protected boolean isInternalType(String type) {
+        for (Predicate<String> p : internalTypes) {
+            if (p.test(type)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/revapi-java/src/main/java/org/revapi/java/checks/classes/InternalTypeWhitelistCheckBase.java
+++ b/revapi-java/src/main/java/org/revapi/java/checks/classes/InternalTypeWhitelistCheckBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Lukas Krejci
+ * Copyright 2014-2018 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/revapi-java/src/main/java/org/revapi/java/checks/classes/Removed.java
+++ b/revapi-java/src/main/java/org/revapi/java/checks/classes/Removed.java
@@ -24,6 +24,7 @@ import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 
+import javax.annotation.Nullable;
 import javax.lang.model.element.TypeElement;
 
 import org.revapi.Difference;
@@ -49,11 +50,13 @@ public final class Removed extends InternalTypeWhitelistCheckBase {
         }
     }
 
+    @Nullable
     @Override
     public String getExtensionId() {
         return "externalClassNoLongerExposedInAPI";
     }
 
+    @Nullable
     @Override
     public Reader getJSONSchema() {
         return new InputStreamReader(getClass().getResourceAsStream("/META-INF/externalClassNoLongerExposedInAPI-config-schema.json"),

--- a/revapi-java/src/main/resources/META-INF/externalClassExposedInAPI-config-schema.json
+++ b/revapi-java/src/main/resources/META-INF/externalClassExposedInAPI-config-schema.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "internalTypes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    }
+  }
+}

--- a/revapi-java/src/main/resources/META-INF/externalClassNoLongerExposedInAPI-config-schema.json
+++ b/revapi-java/src/main/resources/META-INF/externalClassNoLongerExposedInAPI-config-schema.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "internalTypes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    }
+  }
+}

--- a/revapi-java/src/test/java/org/revapi/java/AbstractJavaElementAnalyzerTest.java
+++ b/revapi-java/src/test/java/org/revapi/java/AbstractJavaElementAnalyzerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Lukas Krejci
+ * Copyright 2014-2018 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/revapi-java/src/test/resources/v1/classes/ExternalTypeExposed.java
+++ b/revapi-java/src/test/resources/v1/classes/ExternalTypeExposed.java
@@ -18,6 +18,6 @@
 /**
  * @author James Phillpotts, ForgeRock AS.
  */
-public class ExternalTypeExposed {
+public interface ExternalTypeExposed {
 
 }

--- a/revapi-java/src/test/resources/v1/classes/ExternalTypeExposed.java
+++ b/revapi-java/src/test/resources/v1/classes/ExternalTypeExposed.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Lukas Krejci
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author James Phillpotts, ForgeRock AS.
+ */
+public class ExternalTypeExposed {
+
+}

--- a/revapi-java/src/test/resources/v1/classes/ExternalTypeExposed.java
+++ b/revapi-java/src/test/resources/v1/classes/ExternalTypeExposed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Lukas Krejci
+ * Copyright 2014-2018 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/revapi-java/src/test/resources/v2/classes/ExternalTypeExposed.java
+++ b/revapi-java/src/test/resources/v2/classes/ExternalTypeExposed.java
@@ -21,7 +21,8 @@ import misc.I;
  * @author James Phillpotts, ForgeRock AS.
  */
 public class ExternalTypeExposed {
+    private final I i;
     public ExternalTypeExposed(I i) {
-
+        this.i = i;
     }
 }

--- a/revapi-java/src/test/resources/v2/classes/ExternalTypeExposed.java
+++ b/revapi-java/src/test/resources/v2/classes/ExternalTypeExposed.java
@@ -20,9 +20,6 @@ import misc.I;
 /**
  * @author James Phillpotts, ForgeRock AS.
  */
-public class ExternalTypeExposed {
-    private final I i;
-    public ExternalTypeExposed(I i) {
-        this.i = i;
-    }
+public interface ExternalTypeExposed {
+    void doSomething(I i);
 }

--- a/revapi-java/src/test/resources/v2/classes/ExternalTypeExposed.java
+++ b/revapi-java/src/test/resources/v2/classes/ExternalTypeExposed.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Lukas Krejci
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import misc.I;
+
+/**
+ * @author James Phillpotts, ForgeRock AS.
+ */
+public class ExternalTypeExposed {
+    public ExternalTypeExposed(I i) {
+
+    }
+}

--- a/revapi-java/src/test/resources/v2/classes/ExternalTypeExposed.java
+++ b/revapi-java/src/test/resources/v2/classes/ExternalTypeExposed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Lukas Krejci
+ * Copyright 2014-2018 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The `externalClassExposedInAPI` check thinks that all types that are not in the source of the current module are external. When being run as part of a maven build, it is quite likely that the "external" class actually just comes from another module in a multi-module build. This change allows the whitelisting of internal classes that come from outside the current module.

There's probably better ways to do the matching that I've done, but hopefully this gives the impression of what I'm trying to achieve, and you can give advice on what the best way to do it in a revapi style is.