### PR TITLE
Do not skip transformed difference in cases of multiple transformers.

### DIFF
--- a/revapi-basic-features/src/main/resources/META-INF/classification-schema.json
+++ b/revapi-basic-features/src/main/resources/META-INF/classification-schema.json
@@ -24,7 +24,7 @@
                         "$ref": "#/definitions/classification"
                     },
                     "BINARY": {
-                        "$ref": "#definitions/classification"
+                        "$ref": "#/definitions/classification"
                     },
                     "SEMANTIC": {
                         "$ref": "#/definitions/classification"

--- a/revapi/src/main/java/org/revapi/Revapi.java
+++ b/revapi/src/main/java/org/revapi/Revapi.java
@@ -16,12 +16,7 @@
  */
 package org.revapi;
 
-import org.jboss.dmr.ModelNode;
-import org.revapi.configuration.Configurable;
-import org.revapi.configuration.ConfigurationValidator;
-import org.revapi.configuration.ValidationResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static java.util.Collections.emptySortedSet;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.AbstractMap;
@@ -40,9 +35,15 @@ import java.util.SortedSet;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
 import javax.annotation.Nonnull;
 
-import static java.util.Collections.emptySortedSet;
+import org.jboss.dmr.ModelNode;
+import org.revapi.configuration.Configurable;
+import org.revapi.configuration.ConfigurationValidator;
+import org.revapi.configuration.ValidationResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The main entry point to the library. The instance of this class is initialized with the different extensions and then

--- a/revapi/src/main/java/org/revapi/Revapi.java
+++ b/revapi/src/main/java/org/revapi/Revapi.java
@@ -16,7 +16,12 @@
  */
 package org.revapi;
 
-import static java.util.Collections.emptySortedSet;
+import org.jboss.dmr.ModelNode;
+import org.revapi.configuration.Configurable;
+import org.revapi.configuration.ConfigurationValidator;
+import org.revapi.configuration.ValidationResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.AbstractMap;
@@ -35,15 +40,9 @@ import java.util.SortedSet;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
 import javax.annotation.Nonnull;
 
-import org.jboss.dmr.ModelNode;
-import org.revapi.configuration.Configurable;
-import org.revapi.configuration.ConfigurationValidator;
-import org.revapi.configuration.ValidationResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static java.util.Collections.emptySortedSet;
 
 /**
  * The main entry point to the library. The instance of this class is initialized with the different extensions and then
@@ -387,7 +386,6 @@ public final class Revapi {
             while (it.hasNext()) {
                 Difference d = it.next();
                 transformed.clear();
-                boolean shouldBeRemoved = false;
                 boolean differenceChanged = false;
                 for (DifferenceTransform<?> t : getTransformsForDifference(d, extensions)) {
                     // it is the responsibility of the transform to declare the proper type.
@@ -408,7 +406,6 @@ public final class Revapi {
 
                     // ignore if transformation returned null, meaning that it "swallowed" the difference..
                     if (td == null) {
-                        shouldBeRemoved = true;
                         listChanged = true;
                         differenceChanged = true;
                     } else if (!d.equals(td)) {
@@ -425,7 +422,7 @@ public final class Revapi {
                 if (differenceChanged) {
                     //we need to remove the element in either case
                     it.remove();
-                    if (!shouldBeRemoved) {
+                    if (!transformed.isEmpty()) {
                         //if it was not removed, but transformed, let's add the transformed difference in the place of
                         //our currently removed element
                         for (Difference td : transformed) {

--- a/revapi/src/test/java/org/revapi/AnalysisTest.java
+++ b/revapi/src/test/java/org/revapi/AnalysisTest.java
@@ -16,11 +16,6 @@
  */
 package org.revapi;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.revapi.simple.SimpleElement;
-import org.revapi.simple.SimpleElementForest;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,8 +23,14 @@ import java.io.Reader;
 import java.util.SortedSet;
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.revapi.simple.SimpleElement;
+import org.revapi.simple.SimpleElementForest;
 
 /**
  * @author Lukas Krejci


### PR DESCRIPTION
In the case when the configuration had multiple transformers it was possible
to skip transformed difference in case if any transformer
after actually transforming transformer returns null as the difference.
A described situation can happen, for example, in the case when the configuration has
SemverIgnoreTransformer and ClassificationTransfromer defined.

This PR also fixes a bug in classification-schema.json where `BINARY` value was incorrectly described.