### PR TITLE
Make ANNOTATION_NO_LONGER_PRESENT BREAKING for binary

### DIFF
--- a/revapi-java-spi/src/main/java/org/revapi/java/spi/Code.java
+++ b/revapi-java-spi/src/main/java/org/revapi/java/spi/Code.java
@@ -104,7 +104,7 @@ public enum Code {
         POTENTIALLY_BREAKING, "annotationType"),
     ANNOTATION_NOW_INHERITED("java.annotation.nowInherited", NON_BREAKING, NON_BREAKING, POTENTIALLY_BREAKING,
             "annotationType"),
-    ANNOTATION_NO_LONGER_PRESENT("java.annotation.noLongerPresent", BREAKING, NON_BREAKING, POTENTIALLY_BREAKING),
+    ANNOTATION_NO_LONGER_PRESENT("java.annotation.noLongerPresent", BREAKING, BREAKING, POTENTIALLY_BREAKING),
 
     FIELD_ADDED_STATIC_FIELD("java.field.addedStaticField", NON_BREAKING, NON_BREAKING, null),
     FIELD_ADDED("java.field.added", NON_BREAKING, NON_BREAKING, null),

--- a/revapi-java-spi/src/main/java/org/revapi/java/spi/Code.java
+++ b/revapi-java-spi/src/main/java/org/revapi/java/spi/Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018 Lukas Krejci
+ * Copyright 2014-2019 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/revapi-java-spi/src/main/java/org/revapi/java/spi/Code.java
+++ b/revapi-java-spi/src/main/java/org/revapi/java/spi/Code.java
@@ -104,7 +104,11 @@ public enum Code {
         POTENTIALLY_BREAKING, "annotationType"),
     ANNOTATION_NOW_INHERITED("java.annotation.nowInherited", NON_BREAKING, NON_BREAKING, POTENTIALLY_BREAKING,
             "annotationType"),
-    ANNOTATION_NO_LONGER_PRESENT("java.annotation.noLongerPresent", BREAKING, BREAKING, POTENTIALLY_BREAKING),
+    /**
+     * @deprecated Annotation removal is handled by {@link CLASS_REMOVED}.
+     */
+    @Deprecated
+    ANNOTATION_NO_LONGER_PRESENT("java.annotation.noLongerPresent", BREAKING, NON_BREAKING, POTENTIALLY_BREAKING),
 
     FIELD_ADDED_STATIC_FIELD("java.field.addedStaticField", NON_BREAKING, NON_BREAKING, null),
     FIELD_ADDED("java.field.added", NON_BREAKING, NON_BREAKING, null),

--- a/revapi-java-spi/src/main/resources/org/revapi/java/checks/descriptions.properties
+++ b/revapi-java-spi/src/main/resources/org/revapi/java/checks/descriptions.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Lukas Krejci
+# Copyright 2014-2019 Lukas Krejci
 # and other contributors as indicated by the @author tags.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -60,7 +60,6 @@ java.annotation.attributeValueChanged=Attribute ''{2}'' of annotation ''{0}'' ch
 java.annotation.removed=Element no longer annotated with ''{0}''.
 java.annotation.noLongerInherited=Annotation type is no longer inherited.
 java.annotation.nowInherited=Annotation type is now inherited.
-java.annotation.noLongerPresent=Old API referenced the annotation type but the new API version no longer does.
 
 java.field.added=Field added to class.
 java.field.addedStaticField=Static field added to class.

--- a/revapi-java-spi/src/main/resources/org/revapi/java/checks/names.properties
+++ b/revapi-java-spi/src/main/resources/org/revapi/java/checks/names.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Lukas Krejci
+# Copyright 2014-2019 Lukas Krejci
 # and other contributors as indicated by the @author tags.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,7 +51,6 @@ java.annotation.attributeValueChanged=annotation attribute changed
 java.annotation.removed=removed annotation
 java.annotation.noLongerInherited=annotation no longer inherited
 java.annotation.nowInherited=annotation now inherited
-java.annotation.noLongerPresent=Annotation type no longer present
 
 java.field.added=field added
 java.field.addedStaticField=static field added

--- a/revapi-java/src/main/java/org/revapi/java/transforms/annotations/NoLongerPresent.java
+++ b/revapi-java/src/main/java/org/revapi/java/transforms/annotations/NoLongerPresent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018 Lukas Krejci
+ * Copyright 2014-2019 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,45 +17,36 @@
 package org.revapi.java.transforms.annotations;
 
 import java.io.Reader;
-import java.util.Locale;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.lang.model.element.ElementKind;
 
 import org.revapi.AnalysisContext;
 import org.revapi.Difference;
 import org.revapi.DifferenceTransform;
-import org.revapi.java.spi.Code;
 import org.revapi.java.spi.JavaTypeElement;
 
 /**
+ * @deprecated This transform is no longer used: removed annotations are treated
+ *             as removed classes.
+ *
  * @author Lukas Krejci
  * @since 0.3.0
  */
+@Deprecated
 public class NoLongerPresent implements DifferenceTransform<JavaTypeElement> {
-    private Locale locale;
 
     @Nonnull
     @Override
     public Pattern[] getDifferenceCodePatterns() {
-        return new Pattern[]{Pattern.compile("java\\.class\\.removed")};
+        return new Pattern[0];
     }
 
     @Override
     public @Nullable Difference transform(@Nullable JavaTypeElement oldElement, @Nullable JavaTypeElement newElement,
                                           @Nonnull Difference difference) {
-        if (oldElement == null || newElement != null) {
-            return difference;
-        }
-
-        if (oldElement.getDeclaringElement().getKind() == ElementKind.ANNOTATION_TYPE) {
-            return Code.ANNOTATION_NO_LONGER_PRESENT.createDifference(locale,
-                    Code.attachmentsFor(oldElement, newElement));
-        } else {
-            return difference;
-        }
+        return difference;
     }
 
     @Override
@@ -74,6 +65,5 @@ public class NoLongerPresent implements DifferenceTransform<JavaTypeElement> {
 
     @Override
     public void initialize(AnalysisContext analysisContext) {
-        this.locale = analysisContext.getLocale();
     }
 }

--- a/revapi-java/src/main/resources/META-INF/services/org.revapi.DifferenceTransform
+++ b/revapi-java/src/main/resources/META-INF/services/org.revapi.DifferenceTransform
@@ -16,7 +16,6 @@
 
 org.revapi.java.transforms.annotations.NoLongerDeprecated
 org.revapi.java.transforms.annotations.NoLongerInherited
-org.revapi.java.transforms.annotations.NoLongerPresent
 org.revapi.java.transforms.annotations.NowDeprecated
 org.revapi.java.transforms.annotations.NowInherited
 org.revapi.java.transforms.methods.AnnotationTypeAttributeAdded


### PR DESCRIPTION
`ANNOTATION_NO_LONGER_PRESENT` refers to the deletion of an annotation class definition, which breaks binary compatibility. For example, processing a specific annotation retained at runtime will break if that annotation has been removed:
```java
MyAnnotation annotation = someObject.getClass().getAnnotation(MyAnnotation.class);
```

We were wondering if the `semanticSeverity` should also be changed to `null` as seems to be the case everywhere else that `binarySeverity` is `BREAKING`.

---

Given the above example, my teammates and I were wondering if it makes sense to classify a deleted annotation with `Code.CLASS_REMOVED`, which seems to currently capture classes, abstract classes, and interfaces.

The current messaging for `ANNOTATION_NO_LONGER_PRESENT` also seems to obscure / misrepresent the problem:
> Old API referenced the annotation type but the new API version no longer does.`

Rather than make an opinionated PR with these changes, I wanted to make a basic tweak and start a discussion to hopefully better understand the reasoning behind the current implementation.

---
For reference, we noticed this when looking at `com.google.errorprone:error_prone_annotations` going from `2.0.18` to `2.3.3`:
```
Old API: error_prone_annotations-2.0.18.jar
New API: error_prone_annotations-2.3.3.jar
old: @interface com.google.errorprone.annotations.DoNotMock
new: <none>
java.annotation.noLongerPresent: Old API referenced the annotation type but the new API version no longer does.
SOURCE: BREAKING, SEMANTIC: POTENTIALLY_BREAKING, BINARY: NON_BREAKING
```

---
@metlos 
cc @jhaber @kmclarnon