### PR TITLE
Respect singleVersionForAllModules for added modules

### DIFF
--- a/revapi-maven-plugin/src/it/build/version-handling-multimodule/c/pom.xml
+++ b/revapi-maven-plugin/src/it/build/version-handling-multimodule/c/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2014-2017 Lukas Krejci
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>version.handling.multimodule</groupId>
+    <artifactId>top</artifactId>
+    <version>1.0.1</version>
+  </parent>
+
+  <groupId>version.handling.multimodule</groupId>
+  <artifactId>c</artifactId>
+  <version>1.0.1</version>
+</project>

--- a/revapi-maven-plugin/src/it/build/version-handling-multimodule/c/pom.xml
+++ b/revapi-maven-plugin/src/it/build/version-handling-multimodule/c/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2017 Lukas Krejci
+    Copyright 2014-2020 Lukas Krejci
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/revapi-maven-plugin/src/it/build/version-handling-multimodule/c/src/main/java/C.java
+++ b/revapi-maven-plugin/src/it/build/version-handling-multimodule/c/src/main/java/C.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Lukas Krejci
+ * Copyright 2014-2020 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/revapi-maven-plugin/src/it/build/version-handling-multimodule/c/src/main/java/C.java
+++ b/revapi-maven-plugin/src/it/build/version-handling-multimodule/c/src/main/java/C.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2014-2017 Lukas Krejci
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class C {
+
+}

--- a/revapi-maven-plugin/src/it/build/version-handling-multimodule/pom.xml
+++ b/revapi-maven-plugin/src/it/build/version-handling-multimodule/pom.xml
@@ -30,6 +30,7 @@
   <modules>
     <module>a</module>
     <module>b</module>
+    <module>c</module>
   </modules>
 
   <build>

--- a/revapi-maven-plugin/src/it/build/version-handling-multimodule/pom.xml
+++ b/revapi-maven-plugin/src/it/build/version-handling-multimodule/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2017 Lukas Krejci
+    Copyright 2014-2020 Lukas Krejci
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/revapi-maven-plugin/src/it/build/version-handling-multimodule/postbuild.groovy
+++ b/revapi-maven-plugin/src/it/build/version-handling-multimodule/postbuild.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Lukas Krejci
+ * Copyright 2014-2020 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/revapi-maven-plugin/src/it/build/version-handling-multimodule/postbuild.groovy
+++ b/revapi-maven-plugin/src/it/build/version-handling-multimodule/postbuild.groovy
@@ -47,7 +47,10 @@ File v2aDir = new File(topDir, "a");
 File v2aPom = new File(v2aDir, "pom.xml");
 File v2bDir = new File(topDir, "b");
 File v2bPom = new File(v2bDir, "pom.xml");
+File v2cDir = new File(topDir, "c");
+File v2cPom = new File(v2cDir, "pom.xml");
 
 checkVersion(topPom, "top", "2.0.0");
 checkVersion(v2aPom, "v2a", "2.0.0", "2.0.0");
 checkVersion(v2bPom, "v2b", "2.0.0", "2.0.0");
+checkVersion(v2cPom, "v2c", "2.0.0", "2.0.0");

--- a/revapi-maven-plugin/src/main/java/org/revapi/maven/AbstractVersionModifyingMojo.java
+++ b/revapi-maven-plugin/src/main/java/org/revapi/maven/AbstractVersionModifyingMojo.java
@@ -130,7 +130,7 @@ abstract class AbstractVersionModifyingMojo extends AbstractRevapiMojo {
         }
 
         if (analysisResults == null) {
-            return;
+            analysisResults = new AnalysisResults(ApiChangeLevel.NO_CHANGE, newVersion);
         }
 
         ApiChangeLevel changeLevel = analysisResults.apiChangeLevel;


### PR DESCRIPTION
Modules with no previous artifact were not being written into the changes file, so they were not being kept up to date even when `singleVersionForAllModules` was enabled.

This caused project versions to get out of sync if a new module was added to the project at the same time as any API changes were made to other modules.