### PR TITLE
Add faq documentation about externalClassExposedInAPI (#186)

### DIFF
--- a/revapi-site/src/site/asciidoc/faq.adoc
+++ b/revapi-site/src/site/asciidoc/faq.adoc
@@ -56,3 +56,31 @@ must also be specified to ensure that these extensions are run together and in a
                     </configuration>
                 </plugin>
 ```
+=== How to deal with External Class Exposed In API ?
+This is mainly a warning to ensure that you are exposing class from external dependency on purpose.
+Generally, exposing a class from an external dependency could be considered a bad design because this could make it harder to upgrade to a more recent version of the dependency. One reason amongst others which makes encapsulation a good practice.
+
+But there are use cases where this totally makes sense. The most common one is probably when you have a multi-module Maven project. In this case it is usual to have some modules exposing classes from another "core" or "api" module.
+
+E.g : `myproject-impl` exposes classes from `myproject-core`.  
+
+An easy way to deal with this is to configure revapi like this : 
+```xml
+            <plugin>
+                <groupId>org.revapi</groupId>
+                <artifactId>revapi-maven-plugin</artifactId>
+                <configuration>
+                    <analysisConfiguration>
+                        <revapi.ignore>
+                            <item>
+                                <regex>true</regex>
+                                <code>java.class.externalClassExposedInAPI</code>
+                                <newArchive>org\.my\.project:myproject.*:.*</newArchive>
+                                <justification>
+                                    MyProject sub-modules implement MyProject API which
+                                    makes them expose MyProject specific classes usually.
+                                </justification>
+                            </item>
+                        </revapi.ignore>
+                </plugin>
+```


### PR DESCRIPTION
Adding some documentation about `externalClassExposedInAPI` in F.A.Q.

(triggered by #186)