### PR TITLE
Add createWhenNoError for file based reports

### DIFF
--- a/revapi-reporter-file-base/src/main/resources/org/revapi/reporter/file/default-schema.json
+++ b/revapi-reporter-file-base/src/main/resources/org/revapi/reporter/file/default-schema.json
@@ -19,8 +19,8 @@
       "type": "boolean",
       "default": false
     },
-    "createWhenNoError": {
-      "description": "Whether to create a file when no error or just have at least empty file.",
+    "keepEmptyFile": {
+      "description": "Whether to keep the report file when it contains no data.",
       "type": "boolean",
       "default": "true"
     }

--- a/revapi-reporter-file-base/src/main/resources/org/revapi/reporter/file/default-schema.json
+++ b/revapi-reporter-file-base/src/main/resources/org/revapi/reporter/file/default-schema.json
@@ -3,7 +3,11 @@
   "type": "object",
   "properties": {
     "minSeverity": {
-      "enum": ["NON_BREAKING", "POTENTIALLY_BREAKING", "BREAKING"],
+      "enum": [
+        "NON_BREAKING",
+        "POTENTIALLY_BREAKING",
+        "BREAKING"
+      ],
       "default": "POTENTIALLY_BREAKING"
     },
     "output": {
@@ -14,6 +18,11 @@
       "description": "Whether to append to the output or whether to overwrite it.",
       "type": "boolean",
       "default": false
+    },
+    "createWhenNoError": {
+      "description": "Whether to create a file when no error or just have at least empty file.",
+      "type": "boolean",
+      "default": "true"
     }
   }
 }

--- a/revapi-reporter-file-base/src/site/asciidoc/index.adoc
+++ b/revapi-reporter-file-base/src/site/asciidoc/index.adoc
@@ -31,7 +31,8 @@ implementation. There is no way of reusing that currently so you need to copy it
     "configuration": {
       "minSeverity": "POTENTIALLY_BREAKING",
       "output" : "out",
-      "append": false
+      "append": false,
+      "keepEmptyFile": true
     }
   }
 ]
@@ -43,6 +44,7 @@ implementation. There is no way of reusing that currently so you need to copy it
     <minSeverity>POTENTIALLY_BREAKING</minSeverity>
     <output>out</output>
     <append>false</append>
+    <keepEmptyFile>true</keepEmptyFile>
   </YOUR_EXTENSION>
 </analysisConfiguration>
 ```
@@ -60,4 +62,6 @@ The path to the output file. Two special values are recongized: `out` (which is 
 `append`::
 Whether to append to the chosen output or whether to overwrite it (doesn't make sense for standard (error) output).
 The default value is `false` meaning the output file will be overwritten if it already exists.
-
+`keepEmptyFile`::
+Defaults to `true`. If `true` the output file is kept even if no reports were written to it and thus it is empty. Has
+no effect if `append` is set to `true`.

--- a/revapi-reporter-file-base/src/test/java/org/revapi/reporter/file/AbstractFileReporterTest.java
+++ b/revapi-reporter-file-base/src/test/java/org/revapi/reporter/file/AbstractFileReporterTest.java
@@ -17,6 +17,7 @@
 package org.revapi.reporter.file;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 
 import java.io.File;
@@ -69,21 +70,22 @@ public class AbstractFileReporterTest {
         Path file = Files.createTempFile(null, null);
         try (Reporter reporter = new Reporter()) {
             reporter.initialize(ctxWithOutput(file.toString()));
-        } finally {
+            reporter.close();
             assertReporterWroteToPath(file);
+        } finally {
             Files.delete(file);
         }
     }
 
     @Test
-    public void testCreateWhenNoError() throws Exception {
+    public void testKeepEmptyFiles() throws Exception {
         Path file = Files.createTempFile(null, null);
         try (Reporter reporter = new Reporter()) {
             StringBuffer buf = new StringBuffer();
             buf.append("{");
             buf.append("\"output\": \"").append(file.toString()).append("\"");
             buf.append(",");
-            buf.append("\"createWhenNoError\": \"").append("false").append("\"");
+            buf.append("\"keepEmptyFile\": \"").append("false").append("\"");
             buf.append("}");
 
             reporter.initialize(AnalysisContext.builder()
@@ -91,7 +93,7 @@ public class AbstractFileReporterTest {
             reporter.report(Report.builder().build());
 
         } finally {
-            assertSame(file.toFile().exists(), false);
+            assertFalse(file.toFile().exists());
         }
     }
 
@@ -101,8 +103,9 @@ public class AbstractFileReporterTest {
         file = file.resolve("output.file");
         try (Reporter reporter = new Reporter()) {
             reporter.initialize(ctxWithOutput(file.toString()));
-        } finally {
+            reporter.close();
             assertReporterWroteToPath(file);
+        } finally {
             Files.delete(file);
             Files.delete(file.getParent());
         }
@@ -113,8 +116,9 @@ public class AbstractFileReporterTest {
         Path file = Paths.get("fqefacs" + new Random().nextInt());
         try (Reporter reporter = new Reporter()) {
             reporter.initialize(ctxWithOutput(file.toString()));
-        } finally {
+            reporter.close();
             assertReporterWroteToPath(file);
+        } finally {
             Files.delete(file);
         }
     }
@@ -125,8 +129,9 @@ public class AbstractFileReporterTest {
         file = file.resolve("subdir" + File.separatorChar + "output.file");
         try (Reporter reporter = new Reporter()) {
             reporter.initialize(ctxWithOutput(file.toString()));
-        } finally {
+            reporter.close();
             assertReporterWroteToPath(file);
+        } finally {
             Files.delete(file);
             Files.delete(file.getParent());
             Files.delete(file.getParent().getParent());
@@ -137,14 +142,15 @@ public class AbstractFileReporterTest {
         Path file = Paths.get("subdir" + new Random().nextInt() + File.separatorChar + "output.file");
         try (Reporter reporter = new Reporter()) {
             reporter.initialize(ctxWithOutput(file.toString()));
-        } finally {
+            reporter.close();
             assertReporterWroteToPath(file);
+        } finally {
             Files.delete(file);
             Files.delete(file.getParent());
         }
     }
 
-    private void assertReporterWroteToPath(Path path) throws IOException {
+    private static void assertReporterWroteToPath(Path path) throws IOException {
         String line = Files.lines(path).toArray(String[]::new)[0];
         assertEquals("Test was here!", line);
     }

--- a/revapi-reporter-file-base/src/test/java/org/revapi/reporter/file/AbstractFileReporterTest.java
+++ b/revapi-reporter-file-base/src/test/java/org/revapi/reporter/file/AbstractFileReporterTest.java
@@ -76,6 +76,26 @@ public class AbstractFileReporterTest {
     }
 
     @Test
+    public void testCreateWhenNoError() throws Exception {
+        Path file = Files.createTempFile(null, null);
+        try (Reporter reporter = new Reporter()) {
+            StringBuffer buf = new StringBuffer();
+            buf.append("{");
+            buf.append("\"output\": \"").append(file.toString()).append("\"");
+            buf.append(",");
+            buf.append("\"createWhenNoError\": \"").append("false").append("\"");
+            buf.append("}");
+
+            reporter.initialize(AnalysisContext.builder()
+                    .build().copyWithConfiguration(ModelNode.fromJSONString(buf.toString())));
+            reporter.report(Report.builder().build());
+
+        } finally {
+            assertSame(file.toFile().exists(), false);
+        }
+    }
+
+    @Test
     public void testNonExistingFileAsOutput() throws Exception {
         Path file = Files.createTempDirectory(null);
         file = file.resolve("output.file");

--- a/revapi-reporter-json/src/main/resources/org/revapi/reporter/json/schema.json
+++ b/revapi-reporter-json/src/main/resources/org/revapi/reporter/json/schema.json
@@ -20,6 +20,11 @@
       "description": "Whether to produced indented output for easier human readability.",
       "type": "boolean",
       "default": false
+    },
+    "createWhenNoError": {
+      "description": "Whether to create a file when no error or just have at least empty file.",
+      "type": "boolean",
+      "default": "true"
     }
   }
 }

--- a/revapi-reporter-json/src/main/resources/org/revapi/reporter/json/schema.json
+++ b/revapi-reporter-json/src/main/resources/org/revapi/reporter/json/schema.json
@@ -21,8 +21,8 @@
       "type": "boolean",
       "default": false
     },
-    "createWhenNoError": {
-      "description": "Whether to create a file when no error or just have at least empty file.",
+    "keepEmptyFile": {
+      "description": "Whether to keep the report file when it contains no data.",
       "type": "boolean",
       "default": "true"
     }

--- a/revapi-reporter-json/src/site/asciidoc/index.adoc
+++ b/revapi-reporter-json/src/site/asciidoc/index.adoc
@@ -46,7 +46,8 @@ add the extension as a dependency of the maven plugin like so:
       "minSeverity": "POTENTIALLY_BREAKING",
       "output" : "out",
       "indent": false,
-      "append": false
+      "append": false,
+      "keepEmptyFile": true
     }
   }
 ]
@@ -59,6 +60,7 @@ add the extension as a dependency of the maven plugin like so:
     <output>out</output>
     <indent>false</indent>
     <append>false</append>
+    <keepEmptyFile>true</keepEmptyFile>
   </revapi.reporter.json>
 </analysisConfiguration>
 ```
@@ -74,6 +76,9 @@ The path to the output file. Two special values are recongized: `out` (which is 
 `append`::
 Whether to append to the chosen output or whether to overwrite it (doesn't make sense for standard (error) output).
 The default value is `false` meaning the output file will be overwritten if it already exists.
+`keepEmptyFile`::
+Defaults to `true`. If `true` the output file is kept even if no reports were written to it and thus it is empty. Has
+no effect if `append` is set to `true`.
 `indent`::
 Whether to indent the JSON or leave it in the minimal form. `false` by default to produce minimal
 output.

--- a/revapi-reporter-json/src/test/java/org/revapi/reporter/json/JsonReporterTest.java
+++ b/revapi-reporter-json/src/test/java/org/revapi/reporter/json/JsonReporterTest.java
@@ -18,11 +18,14 @@ package org.revapi.reporter.json;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
 
 import java.io.File;
 import java.io.PrintWriter;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,6 +36,7 @@ import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
 
+import org.jboss.dmr.ModelNode;
 import org.junit.Test;
 import org.revapi.API;
 import org.revapi.AnalysisContext;
@@ -42,11 +46,32 @@ import org.revapi.DifferenceSeverity;
 import org.revapi.Element;
 import org.revapi.PipelineConfiguration;
 import org.revapi.Report;
+import org.revapi.Reporter;
 import org.revapi.Revapi;
 import org.revapi.simple.FileArchive;
 import org.revapi.simple.SimpleElement;
 
 public class JsonReporterTest {
+
+    @Test
+    public void testCreateWhenNoError() throws Exception {
+        Path file = Files.createTempFile(null, null);
+        try (Reporter reporter = new JsonReporter()) {
+            StringBuffer buf = new StringBuffer();
+            buf.append("{");
+            buf.append("\"output\": \"").append(file.toString()).append("\"");
+            buf.append(",");
+            buf.append("\"createWhenNoError\": \"").append("false").append("\"");
+            buf.append("}");
+
+            reporter.initialize(AnalysisContext.builder()
+                    .build().copyWithConfiguration(ModelNode.fromJSONString(buf.toString())));
+            reporter.report(Report.builder().build());
+
+        } finally {
+            assertSame(file.toFile().exists(), false);
+        }
+    }
 
     @Test
     public void testReportsWritten() throws Exception {

--- a/revapi-reporter-json/src/test/java/org/revapi/reporter/json/JsonReporterTest.java
+++ b/revapi-reporter-json/src/test/java/org/revapi/reporter/json/JsonReporterTest.java
@@ -19,7 +19,6 @@ package org.revapi.reporter.json;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertSame;
 
 import java.io.File;
 import java.io.PrintWriter;

--- a/revapi-reporter-json/src/test/java/org/revapi/reporter/json/JsonReporterTest.java
+++ b/revapi-reporter-json/src/test/java/org/revapi/reporter/json/JsonReporterTest.java
@@ -17,6 +17,7 @@
 package org.revapi.reporter.json;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 
@@ -54,14 +55,14 @@ import org.revapi.simple.SimpleElement;
 public class JsonReporterTest {
 
     @Test
-    public void testCreateWhenNoError() throws Exception {
+    public void testKeepEmptyFile() throws Exception {
         Path file = Files.createTempFile(null, null);
         try (Reporter reporter = new JsonReporter()) {
             StringBuffer buf = new StringBuffer();
             buf.append("{");
             buf.append("\"output\": \"").append(file.toString()).append("\"");
             buf.append(",");
-            buf.append("\"createWhenNoError\": \"").append("false").append("\"");
+            buf.append("\"keepEmptyFile\": \"").append("false").append("\"");
             buf.append("}");
 
             reporter.initialize(AnalysisContext.builder()
@@ -69,7 +70,7 @@ public class JsonReporterTest {
             reporter.report(Report.builder().build());
 
         } finally {
-            assertSame(file.toFile().exists(), false);
+            assertFalse(file.toFile().exists());
         }
     }
 

--- a/revapi-reporter-text/src/main/resources/org/revapi/reporter/text/schema.json
+++ b/revapi-reporter-text/src/main/resources/org/revapi/reporter/text/schema.json
@@ -18,6 +18,11 @@
             "description": "Whether to append to the output or whether to overwrite it.",
             "type": "boolean",
             "default": false
+        },
+        "createWhenNoError": {
+            "description": "Whether to create a file when no error or just have at least empty file.",
+            "type": "boolean",
+            "default": "true"
         }
     }
 }

--- a/revapi-reporter-text/src/main/resources/org/revapi/reporter/text/schema.json
+++ b/revapi-reporter-text/src/main/resources/org/revapi/reporter/text/schema.json
@@ -19,8 +19,8 @@
             "type": "boolean",
             "default": false
         },
-        "createWhenNoError": {
-            "description": "Whether to create a file when no error or just have at least empty file.",
+        "keepEmptyFile": {
+            "description": "Whether to keep the report file when it contains no data.",
             "type": "boolean",
             "default": "true"
         }

--- a/revapi-reporter-text/src/site/asciidoc/index.adoc
+++ b/revapi-reporter-text/src/site/asciidoc/index.adoc
@@ -48,7 +48,8 @@ add the extension as a dependency of the maven plugin like so:
       "minSeverity": "POTENTIALLY_BREAKING",
       "output" : "out",
       "template": "my-template.ftl",
-      "append": false
+      "append": false,
+      "keepEmptyFile": true
     }
   }
 ]
@@ -61,6 +62,7 @@ add the extension as a dependency of the maven plugin like so:
     <output>out</output>
     <template>my-template.ftl</template>
     <append>false</append>
+    <keepEmptyFile>true</keepEmptyFile>
   </revapi.reporter.text>
 </analysisConfiguration>
 ```
@@ -78,6 +80,9 @@ A relative path to a FreeMarker template to format the output with. If not speci
 `append`::
 Whether to append to the chosen output or whether to overwrite it (doesn't make sense for standard (error) output).
 The default value is `false` meaning the output file will be overwritten if it already exists.
+`keepEmptyFile`::
+Defaults to `true`. If `true` the output file is kept even if no reports were written to it and thus it is empty. Has
+no effect if `append` is set to `true`.
 
 === Example Template
 


### PR DESCRIPTION
Why:

 * currently when no errors occur the files are by default just empty.
 * would be nice to only get a file if there actually are issues.

This change addreses the need by:

 * adds a "createWhenNoError" option for file based reports.
 * technically what it does though that it deletes the file if no errors found
   AND append is false.

Fixes #199