### PR TITLE
changed hierarchy

### DIFF
--- a/revapi-java-spi/src/test/java/org/revapi/java/test/StringRepresentationTest.java
+++ b/revapi-java-spi/src/test/java/org/revapi/java/test/StringRepresentationTest.java
@@ -194,7 +194,7 @@ public class StringRepresentationTest {
         ExecutableElement containsMethod = ElementFilter.methodsIn(MoneyRange.getEnclosedElements()).stream()
                 .filter(m -> m.getSimpleName().contentEquals("contains")).findFirst().get();
 
-        String expected = "boolean Issue238.MoneyRange<T extends java.lang.Comparable<? super T>>::contains(T)";
+        String expected = "boolean Issue238.MoneyRange::contains(Issue238.Money)";
 
         assertEquals(expected, Util.toHumanReadableString(containsMethod));
     }

--- a/revapi-java-spi/src/test/resources/Issue238.java
+++ b/revapi-java-spi/src/test/resources/Issue238.java
@@ -1,20 +1,26 @@
 import java.io.Serializable;
 
 public class Issue238 {
-    public interface ValueSet extends Serializable {}
-    public interface Range<T extends Comparable<? super T>> extends ValueSet {
+    public interface ValueSet<T> extends Serializable {
         boolean contains(T value);
     }
+    public interface Range<T extends Comparable<? super T>> extends ValueSet<T> {}
     public class DefaultRange<T extends Comparable<? super T>> implements Range<T> {
         @Override
         public boolean contains(T value) {
             return false;
         }
     }
-    public class MoneyRange<T extends Comparable<? super T>> extends DefaultRange<T> {
+    public class MoneyRange extends DefaultRange<Money> {
         @Override
-        public boolean contains(T value) {
+        public boolean contains(Money value) {
             return false;
+        }
+    }
+    public class Money implements Comparable<Money>, Serializable {
+        @Override
+        public int compareTo(Money other) {
+            return 1;
         }
     }
 }

--- a/revapi-java-spi/src/test/resources/Issue238.java
+++ b/revapi-java-spi/src/test/resources/Issue238.java
@@ -1,4 +1,6 @@
 import java.io.Serializable;
+import java.util.Currency;
+import java.lang.Comparable;
 
 public class Issue238 {
     public interface ValueSet<T> extends Serializable {
@@ -6,18 +8,59 @@ public class Issue238 {
     }
     public interface Range<T extends Comparable<? super T>> extends ValueSet<T> {}
     public class DefaultRange<T extends Comparable<? super T>> implements Range<T> {
+        
+        private final T lower;
+        private final T upper;
+        private final T step;
+        
+        public DefaultRange() {
+            lower = null;
+            upper = null;
+            step = null;
+        }
+
+        public DefaultRange(T lower, T upper, T step) {
+            this.lower = lower;
+            this.upper = upper;
+            this.step = step;
+        }
+
         @Override
         public boolean contains(T value) {
             return false;
         }
     }
     public class MoneyRange extends DefaultRange<Money> {
+        
+        public MoneyRange EMPTY = new MoneyRange();
+
+        public MoneyRange() {
+            super();
+        }
+
+        public MoneyRange(Money lower, Money upper, Money step) {
+            super(lower, upper, step);
+        }
+        
         @Override
         public boolean contains(Money value) {
             return false;
         }
     }
     public class Money implements Comparable<Money>, Serializable {
+
+        private final Double ammount;
+        private final Currency currency;
+
+        Money(Double ammount, Currency currency) {
+            this.ammount = ammount;
+            this.currency = currency;
+        }
+
+        public final Money valueOf(Double value, Currency currency) {
+            return new Money(value, currency);
+        } 
+
         @Override
         public int compareTo(Money other) {
             return 1;


### PR DESCRIPTION
The hierarchy should look like this. 

If you like to see the original java, before overwriting the contains method:  https://github.com/faktorips/faktorips.base/blob/daef11db4b57b6171a0966fbf7e78fe1bb8700ba/org.faktorips.valuetypes/src/org/faktorips/valueset/MoneyRange.java 