### PR TITLE
Minor improvements to the documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,9 +2,9 @@
 :toc:
 
 image:https://github.com/revapi/revapi/actions/workflows/build.yml/badge.svg[Build Status, link=https://github.com/revapi/revapi/actions/workflows/build.yml]
-image:http://codecov.io/github/revapi/revapi/coverage.svg?branch=main[Code Coverage,link=https://codecov.io/github/revapi/revapi?branch=main]
+image:https://codecov.io/github/revapi/revapi/coverage.svg?branch=main[Code Coverage,link=https://codecov.io/github/revapi/revapi?branch=main]
 
-http://revapi.org[Revapi] is a tool for API analysis and change tracking.
+https://revapi.org[Revapi] is a tool for API analysis and change tracking.
 
 == Summary
 
@@ -67,7 +67,7 @@ Read the usage info and go.
                     <groupId>org.revapi</groupId>
                     <artifactId>revapi-java</artifactId>
                     <version>...</version>
-                </dependency>    
+                </dependency>
                 <dependency>
                     <groupId>com.acme</groupId>
                     <artifactId>my-extension</artifactId>
@@ -88,9 +88,9 @@ Read the usage info and go.
             </executions>
         </plugin>
         ...
-    </plugins>    
+    </plugins>
     ...
-</build>    
+</build>
 ----
 
 === Gradle

--- a/revapi-ant-task/README.adoc
+++ b/revapi-ant-task/README.adoc
@@ -10,7 +10,7 @@ Revapi is a build tool that strives for easy integration of API evolution checks
 It is mainly targeted at developers that want to make sure their code provides stable API for its users across different
 versions.
 
-See http://revapi.org[Revapi site] for details on how to use it.
+See https://revapi.org[Revapi site] for details on how to use it.
 
 == About Revapi Ant Task
 

--- a/revapi-basic-features/README.adoc
+++ b/revapi-basic-features/README.adoc
@@ -10,7 +10,7 @@ Revapi is a build tool that strives for easy integration of API evolution checks
 It is mainly targeted at developers that want to make sure their code provides stable API for its users across different
 versions.
 
-See http://revapi.org[Revapi site] for details on how to use it.
+See https://revapi.org[Revapi site] for details on how to use it.
 
 == About Revapi Basic Features
 
@@ -30,4 +30,3 @@ IRC:: #revapi @ freenode
 Mailing list:: https://groups.google.com/forum/#!forum/revapi, revapi@googlegroups.com
 Issues:: individual subprojects under https://github.com/revapi
 Code:: https://github.com/revapi/
-

--- a/revapi-basic-features/src/site/modules/ROOT/pages/filter.adoc
+++ b/revapi-basic-features/src/site/modules/ROOT/pages/filter.adoc
@@ -7,7 +7,7 @@ can be used to either filter out certain elements in the APIs from the analysis 
 only to configured elements.
 
 If no include or exclude filters are defined, everything is included. If at least 1 include filter is defined, only
-the matching elements are included. Out of the included elements, some may be futher excluded by the provided exclude
+the matching elements are included. Out of the included elements, some may be further excluded by the provided exclude
 filters (if any). If only exclude filters are defined, everything but the elements matching the exclude filters is
 included.
 

--- a/revapi-basic-features/src/site/modules/ROOT/pages/semver-ignore.adoc
+++ b/revapi-basic-features/src/site/modules/ROOT/pages/semver-ignore.adoc
@@ -5,7 +5,7 @@
 WARNING: This extension is deprecated. Use the xref:versions.adoc[] extension instead.
 
 Using this extension one can automatically ignore API changes that are allowed for a given version delta based on the
-rules of semantic versioning (http://semver.org).
+rules of semantic versioning (https://semver.org).
 
 == Sample Configuration
 

--- a/revapi-build/README.adoc
+++ b/revapi-build/README.adoc
@@ -8,7 +8,7 @@ Revapi is a build tool that strives for easy integration of API evolution checks
 It is mainly targeted at developers that want to make sure their code provides stable API for its users across different
 versions.
 
-See http://revapi.org[Revapi site] for details on how to use it.
+See https://revapi.org[Revapi site] for details on how to use it.
 
 == Getting in touch
 
@@ -16,4 +16,3 @@ IRC:: #revapi @ freenode
 Mailing list:: https://groups.google.com/forum/#!forum/revapi, revapi@googlegroups.com
 Issues:: individual subprojects under https://github.com/revapi
 Code:: https://github.com/revapi/
-

--- a/revapi-java-spi/src/main/java/org/revapi/java/spi/Util.java
+++ b/revapi-java-spi/src/main/java/org/revapi/java/spi/Util.java
@@ -1034,7 +1034,7 @@ public final class Util {
      * @param type
      *            the type
      *
-     * @return the list of super tpyes
+     * @return the list of super types
      */
     @Nonnull
     public static List<TypeMirror> getAllSuperTypes(@Nonnull Types types, @Nonnull TypeMirror type) {

--- a/revapi-java-spi/src/site/modules/ROOT/pages/index.adoc
+++ b/revapi-java-spi/src/site/modules/ROOT/pages/index.adoc
@@ -13,9 +13,9 @@ The below two examples show the two major extension points of Revapi's Java chec
 In this example it will be shown how to extend the Revapi's java API checking capabilities. We will use the
 link:{attachmentsdir}/apidocs/org/revapi/java/spi/Check.html[hook interface] into the java checking process that
 represents the Revapi's API elements as Java's own
-http://docs.oracle.com/javase/8/docs/api/javax/lang/model/package-summary.html[model elements].
+https://docs.oracle.com/javase/8/docs/api/javax/lang/model/package-summary.html[model elements].
 
-The checking framework then can use the Java plaform's own rich functionality for examining the classes in the checked
+The checking framework then can use the Java platform's own rich functionality for examining the classes in the checked
 libraries (note, that this API is NOT the reflection API, because it actually doesn't load the library classes into Java
 runtime).
 
@@ -127,7 +127,7 @@ public class IgnoreNewMethodsOnEJBInterfaces implements DifferenceTransform<Java
 
 In addition to the code itself, the class needs to be registered as an Revapi extension. For that it needs to be made
 a java service. Create a file called `src/main/resources/META-INF/services/org.revapi.DifferenceTransform` and
-add a line to it with the fully qualified name of the above class, i.e `my.extension.IgnoreNewMethodsOnEJBInterfaces`.
+add a line to it with the fully qualified name of the above class, i.e. `my.extension.IgnoreNewMethodsOnEJBInterfaces`.
 
 === Usage
 

--- a/revapi-java/src/site/modules/ROOT/pages/differences.adoc
+++ b/revapi-java/src/site/modules/ROOT/pages/differences.adoc
@@ -114,7 +114,7 @@ be used when matching the difference for example in the `revapi.ignore` extensio
 The above will instruct Revapi to not report the removal of `my.Interface` from the list of implemented interfaces on
 any class in the `my` package (or any other subpackage).
 
-All types of differences report the archives that the element come from using these match parametes:
+All types of differences report the archives that the element come from using these match parameters:
 [cols="35s,<65d"]
 |=============
 |`oldArchive` | The name of the archive where the old element comes from, if any
@@ -315,7 +315,7 @@ A class that used to be final is now not. This is no API breakage and is reporte
 |====
 
 NOTE: Modifiers are sorted according to the
-link:http://cr.openjdk.java.net/~alundblad/styleguide/index-v6.html#toc-modifiers[Java style guidelines] in the
+link:https://cr.openjdk.java.net/~alundblad/styleguide/index-v6.html#toc-modifiers[Java style guidelines] in the
 following order: `public protected private abstract static final transient volatile default synchronized native
 strictfp`.
 

--- a/revapi-maven-plugin/README.adoc
+++ b/revapi-maven-plugin/README.adoc
@@ -10,7 +10,7 @@ Revapi is a build tool that strives for easy integration of API evolution checks
 It is mainly targeted at developers that want to make sure their code provides stable API for its users across different
 versions.
 
-See http://revapi.org[Revapi site] for details on how to use it.
+See https://revapi.org[Revapi site] for details on how to use it.
 
 == About Revapi Maven Plugin
 

--- a/revapi-maven-plugin/src/main/java/org/revapi/maven/AbstractRevapiMojo.java
+++ b/revapi-maven-plugin/src/main/java/org/revapi/maven/AbstractRevapiMojo.java
@@ -54,7 +54,7 @@ abstract class AbstractRevapiMojo extends AbstractMojo {
 
     /**
      * The JSON or XML configuration of various analysis options. The available options depend on what analyzers are
-     * present on the plugin classpath through the {@code &lt;dependencies&gt;}. Consult
+     * present on the plugin classpath through the {@code <dependencies>}. Consult
      * <a href="examples/configuration.html">configuration documentation</a> for more details.
      *
      * <p>
@@ -75,7 +75,7 @@ abstract class AbstractRevapiMojo extends AbstractMojo {
 
     /**
      * The list of files containing the configuration of various analysis options. The available options depend on what
-     * analyzers are present on the plugins classpath through the {@code &lt;dependencies&gt;}.
+     * analyzers are present on the plugins classpath through the {@code <dependencies>}.
      *
      * <p>
      * The {@code analysisConfiguration} can override the settings present in the files.

--- a/revapi-maven-plugin/src/main/java/org/revapi/maven/ReportMojo.java
+++ b/revapi-maven-plugin/src/main/java/org/revapi/maven/ReportMojo.java
@@ -63,7 +63,7 @@ public class ReportMojo extends AbstractMavenReport {
 
     /**
      * The JSON or XML configuration of various analysis options. The available options depend on what analyzers are
-     * present on the plugin classpath through the {@code &lt;dependencies&gt;}. Consult
+     * present on the plugin classpath through the {@code <dependencies>}. Consult
      * <a href="examples/configuration.html">configuration documentation</a> for more details.
      *
      * <p>
@@ -74,7 +74,7 @@ public class ReportMojo extends AbstractMavenReport {
 
     /**
      * The list of files containing the configuration of various analysis options. The available options depend on what
-     * analyzers are present on the plugins classpath through the {@code &lt;dependencies&gt;}.
+     * analyzers are present on the plugins classpath through the {@code <dependencies>}.
      *
      * <p>
      * The {@code analysisConfiguration} can override the settings present in the files.

--- a/revapi-maven-plugin/src/site/modules/ROOT/pages/configuring-revapi.adoc
+++ b/revapi-maven-plugin/src/site/modules/ROOT/pages/configuring-revapi.adoc
@@ -90,7 +90,7 @@ to Revapi analysis configuration, too.
 Here is a couple of tips on how to make the Maven configuration inheritance work nice with Revapi analysis
 configuration.
 
-TIP: link:http://maven.apache.org/plugins/maven-help-plugin/effective-pom-mojo.html[`mvn help:effective-pom`],
+TIP: link:https://maven.apache.org/plugins/maven-help-plugin/effective-pom-mojo.html[`mvn help:effective-pom`],
 link:https://maven.apache.org/pom.html#Plugins[`combine.self` and `combine.children`] are your friends when inheriting
 more complex analysis configurations.
 

--- a/revapi-maven-plugin/src/site/modules/ROOT/pages/index.adoc
+++ b/revapi-maven-plugin/src/site/modules/ROOT/pages/index.adoc
@@ -12,9 +12,9 @@ configuration supplied at the top-level aggregator project.
 * link:{attachmentsdir}/validate-configuration-mojo.html[revapi:validate-configuration] validates the configuration of Revapi (use
 this to debug problems with the configuration).
 * link:{attachmentsdir}/update-versions-mojo.html[revapi:update-versions] updates the version string in pom.xml according to
-http://semver.org[semver] rules.
+https://semver.org[semver] rules.
 * link:{attachmentsdir}/update-release-properties-mojo.html[revapi:update-release-properties] updates the `release.properties` file
-with the release and development versions as determined by Revapi according to the http://semver.org[semver] rules.
+with the release and development versions as determined by Revapi according to the https://semver.org[semver] rules.
 
 The full description of all available goals is located link:{attachmentsdir}/plugin-info.html[here].
 
@@ -35,7 +35,7 @@ your concern. Especially for fixing bugs it is crucial that the developers can r
 entire debug logs, POMs or most preferably little demo projects attached to the issue are very much appreciated.
 Of course, patches are most welcome, too. Contributors can check out the project from our
 link:{attachmentsdir}/source-repository.html[source repository] and will find supplementary information in the
-http://maven.apache.org/guides/development/guide-helping.html[guide to helping with Maven].
+https://maven.apache.org/guides/development/guide-helping.html[guide to helping with Maven].
 
 === Examples
 

--- a/revapi-maven-plugin/src/site/modules/ROOT/pages/specifying-versions.adoc
+++ b/revapi-maven-plugin/src/site/modules/ROOT/pages/specifying-versions.adoc
@@ -148,5 +148,5 @@ Thus, running:
 mvn revapi:update-release-properties && mvn release:prepare
 ```
 
-will automatically set the release and development versions for you according to the http://semver.org[semver]
+will automatically set the release and development versions for you according to the https://semver.org[semver]
 versioning rules.

--- a/revapi-maven-utils/README.adoc
+++ b/revapi-maven-utils/README.adoc
@@ -10,7 +10,7 @@ Revapi is a build tool that strives for easy integration of API evolution checks
 It is mainly targeted at developers that want to make sure their code provides stable API for its users across different
 versions.
 
-See http://revapi.org[Revapi site] for details on how to use it.
+See https://revapi.org[Revapi site] for details on how to use it.
 
 == About Revapi Maven Utilities
 
@@ -26,4 +26,3 @@ IRC:: #revapi @ freenode
 Mailing list:: https://groups.google.com/forum/#!forum/revapi, revapi@googlegroups.com
 Issues:: individual subprojects under https://github.com/revapi
 Code:: https://github.com/revapi/
-

--- a/revapi-parent/README.adoc
+++ b/revapi-parent/README.adoc
@@ -39,7 +39,7 @@ Read the usage info and go.
                     <groupId>org.revapi</groupId>
                     <artifactId>revapi-java</artifactId>
                     <version>...</version>
-                </dependency>    
+                </dependency>
                 <dependency>
                     <groupId>com.acme</groupId>
                     <artifactId>my-extension</artifactId>
@@ -60,9 +60,9 @@ Read the usage info and go.
             </executions>
         </plugin>
         ...
-    </plugins>    
+    </plugins>
     ...
-</build>    
+</build>
 ----
 
 
@@ -82,7 +82,7 @@ revapi.analyze(analysisContext);
 
 == Extending Revapi
 
-See the http://revapi.org/docs/architecture.html[site] for more info.
+See the architecture section on the https://revapi.org[Revapi site] for more info.
 
 == Getting in touch
 
@@ -90,4 +90,3 @@ IRC:: #revapi @ freenode
 Mailing list:: https://groups.google.com/forum/#!forum/revapi, revapi@googlegroups.com
 Issues:: individual subprojects under https://github.com/revapi
 Code:: https://github.com/revapi/
-

--- a/revapi-reporter-text/README.adoc
+++ b/revapi-reporter-text/README.adoc
@@ -10,7 +10,7 @@ Revapi is a build tool that strives for easy integration of API evolution checks
 It is mainly targeted at developers that want to make sure their code provides stable API for its users across different
 versions.
 
-See http://revapi.org[Revapi site] for details on how to use it.
+See https://revapi.org[Revapi site] for details on how to use it.
 
 == About Revapi Text Reporter
 
@@ -27,5 +27,3 @@ IRC:: #revapi @ freenode
 Mailing list:: https://groups.google.com/forum/#!forum/revapi, revapi@googlegroups.com
 Issues:: individual subprojects under https://github.com/revapi
 Code:: https://github.com/revapi/
-
-

--- a/revapi-reporter-text/src/site/modules/ROOT/pages/index.adoc
+++ b/revapi-reporter-text/src/site/modules/ROOT/pages/index.adoc
@@ -4,7 +4,7 @@
 
 This extension is used as a basic means of outputting the results of analysis as text to some file or standard output.
 
-The format of the text can be configured using a http://freemarker.org[FreeMarker] template.
+The format of the text can be configured using a https://freemarker.apache.org[FreeMarker] template.
 
 == Usage
 

--- a/revapi-site/README.adoc
+++ b/revapi-site/README.adoc
@@ -2,7 +2,7 @@
 
 image:https://travis-ci.org/revapi/revapi-site.svg[Build Status,link=https://travis-ci.org/revapi/revapi-site]
 
-A maven module with the source code of the http://revapi.org site.
+A maven module with the source code of the https://revapi.org site.
 
 == About Revapi
 
@@ -10,11 +10,11 @@ Revapi is a build tool that strives for easy integration of API evolution checks
 It is mainly targeted at developers that want to make sure their code provides stable API for its users across different
 versions.
 
-See http://revapi.org[Revapi site] for details on how to use it.
+See https://revapi.org[Revapi site] for details on how to use it.
 
 == About Revapi Site
 
-This uses http://awestruct.org[Awestruct] and AsciiDoc for site generation. Therefore it is required that you have
+This uses https://www.awestruct.org[Awestruct] and AsciiDoc for site generation. Therefore it is required that you have
 Awestruct properly installed on your computer prior to being able to build this.
 
 == Building
@@ -27,5 +27,3 @@ IRC:: #revapi @ freenode
 Mailing list:: https://groups.google.com/forum/#!forum/revapi, revapi@googlegroups.com
 Issues:: individual subprojects under https://github.com/revapi
 Code:: https://github.com/revapi/
-
-

--- a/revapi-site/src/site/modules/ROOT/pages/building.adoc
+++ b/revapi-site/src/site/modules/ROOT/pages/building.adoc
@@ -40,14 +40,13 @@ the modules specified.
 where `<list-of-modules>` is a space-separated list of the names of the module directories.
 
 This will deploy all the modules that were either specified on the command line or that
-are dependent on the specified modules to Maven Central staging reposistory.
+are dependent on the specified modules to Maven Central staging repository.
 
 To finish the release, do the following:
 
-. Go to http://oss.sonatype.org, log in and check that the artifacts are ready to be published.
+. Go to https://oss.sonatype.org, log in and check that the artifacts are ready to be published.
 
-. Release the artifacts from http://oss.sonatype.org.
+. Release the artifacts from https://oss.sonatype.org.
 
 . Many of the modules contain parts of the site specific to them. These are published as part of the release process
   automatically. To make the staged site changes public:
-

--- a/revapi-site/src/site/modules/ROOT/pages/index.adoc
+++ b/revapi-site/src/site/modules/ROOT/pages/index.adoc
@@ -72,6 +72,5 @@ Documentation:: xref:getting-started.adoc[start here]
 Twitter:: https://twitter.com/revapi_org[@revapi_org]
 IRC:: #revapi on freenode.net
 Matrix:: #revapiorg:matrix.org
-Forum:: http://stackoverflow.com[stackoverflow]
+Forum:: https://stackoverflow.com[stackoverflow]
 Mailing list:: https://groups.google.com/forum/#!forum/revapi, revapi@googlegroups.com
-

--- a/revapi-site/src/site/modules/news/pages/news/20210108-releases.adoc
+++ b/revapi-site/src/site/modules/news/pages/news/20210108-releases.adoc
@@ -5,7 +5,7 @@
 This is possibly the biggest Revapi release in its 7 years history. Prominently, this release finally
 introduces an almost all-powerful filtering of java elements using the
 https://github.com/revapi/classif[Classif] library and thus closes one of the oldest open issues -
-https://github.com/revapi/issues/17[#17] (almost exactly 5 years old).
+https://github.com/revapi/revapi/issues/17[#17] (almost exactly 5 years old).
 
 But that is actually a smaller part of the release. The underlying extension schema validator has been ported from an
 ancient tv4.js (executed using a script manager that is being phased out in Java) to the Java-based
@@ -39,4 +39,3 @@ up-to-date).
 
 So head over to xref:ROOT:downloads.adoc[] and check out all the new goodness (and please report any issues you
 encounter :) ).
-

--- a/revapi-standalone/README.adoc
+++ b/revapi-standalone/README.adoc
@@ -10,7 +10,7 @@ Revapi is a build tool that strives for easy integration of API evolution checks
 It is mainly targeted at developers that want to make sure their code provides stable API for its users across different
 versions.
 
-See http://revapi.org[Revapi site] for details on how to use it.
+See https://revapi.org[Revapi site] for details on how to use it.
 
 == About Revapi Standalone
 
@@ -32,5 +32,3 @@ IRC:: #revapi @ freenode
 Mailing list:: https://groups.google.com/forum/#!forum/revapi, revapi@googlegroups.com
 Issues:: individual subprojects under https://github.com/revapi
 Code:: https://github.com/revapi/
-
-

--- a/revapi/README.adoc
+++ b/revapi/README.adoc
@@ -10,7 +10,7 @@ Revapi is a build tool that strives for easy integration of API evolution checks
 It is mainly targeted at developers that want to make sure their code provides stable API for its users across different
 versions.
 
-See http://revapi.org[Revapi site] for details on how to use it.
+See https://revapi.org[Revapi site] for details on how to use it.
 
 == About Revapi API
 
@@ -27,4 +27,3 @@ IRC:: #revapi @ freenode
 Mailing list:: https://groups.google.com/forum/#!forum/revapi, revapi@googlegroups.com
 Issues:: individual subprojects under https://github.com/revapi
 Code:: https://github.com/revapi/
-

--- a/revapi/src/site/modules/ROOT/pages/extending-revapi.adoc
+++ b/revapi/src/site/modules/ROOT/pages/extending-revapi.adoc
@@ -16,7 +16,7 @@ a version of an archive, you should supply an implementation of the
 link:{attachmentsdir}/apidocs/org/revapi/Archive.Versioned.html[`Archive.Versioned`] interface instead of just a plain
 `Archive`.
 
-Revapi provides just a basic file-based link:{attachmentsdir}/apidocs/org/revapi/simple/FileArchive.html[implementation]
+Revapi provides just a basic file-based link:{attachmentsdir}/apidocs/org/revapi/base/FileArchive.html[implementation]
 of this interface, but it is trivial to implement one. For example the maven extension has its own implementation of the
 `Archive.Versioned` interface which is able to return the version of the underlying Maven artifact.
 


### PR DESCRIPTION
- fixed broken apidocs and architecture links
- minor spelling corrections
- removed unnecessary (and not rendered) HTML encoding from `{@code }` JavaDoc markup
- using https in READMEs where possible
- using https in Antora adoc where possible (although it seems to be changed automatically)