### PR TITLE
Remove `<item>` tags from configuration

### DIFF
--- a/revapi-basic-features/src/site/modules/ROOT/pages/versions.adoc
+++ b/revapi-basic-features/src/site/modules/ROOT/pages/versions.adoc
@@ -351,20 +351,12 @@ methods to interfaces as a breaking change.
 <revapi.versions>
     <versionIncreaseAllows>
         <minor>
-            <item>
-                <code>java.method.addedToInterface</code>
-            </item>
-            <item>
-                <severity>NON_BREAKING</severity>
-            </item>
+            <code>java.method.addedToInterface</code>
+            <severity>NON_BREAKING</severity>
         </minor>
         <patch>
-            <item>
-                <code>java.method.addedToInterface</code>
-            </item>
-            <item>
-                <severity>EQUIVALENT</severity>
-            </item>
+            <code>java.method.addedToInterface</code>
+            <severity>EQUIVALENT</severity>
         </patch>
     </versionIncreaseAllows>
 </revapi.versions>
@@ -420,34 +412,22 @@ With the transform block in place, we can configure the manually vetted differen
             <revapi.versions>
                 <versionIncreaseAllows>
                     <major>
-                        <item>
-                            <severity>BREAKING</severity>
-                        </item>
-                        <item>
-                            <attachments>
-                                <vetted>ok</vetted>
-                            </attachments>
-                        </item>
+                        <severity>BREAKING</severity>
+                        <attachments>
+                            <vetted>ok</vetted>
+                        </attachments>
                     </major>
                     <minor>
-                        <item>
-                            <severity>NON_BREAKING</severity>
-                        </item>
-                        <item>
-                            <attachments>
-                                <vetted>ok</vetted>
-                            </attachments>
-                        </item>
+                        <severity>NON_BREAKING</severity>
+                        <attachments>
+                            <vetted>ok</vetted>
+                        </attachments>
                     </minor>
                     <patch>
-                        <item>
-                            <severity>EQUIVALENT</severity>
-                        </item>
-                        <item>
-                            <attachments>
-                                <vetted>ok</vetted>
-                            </attachments>
-                        </item>
+                        <severity>EQUIVALENT</severity>
+                        <attachments>
+                            <vetted>ok</vetted>
+                        </attachments>
                     </patch>
                 </versionIncreaseAllows>
             </revapi.versions>


### PR DESCRIPTION
Otherwise maven build will break:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.920 s
[INFO] Finished at: 2022-09-11T15:49:37+02:00
[INFO] ------------------------------------------------------------------------
[WARNING] The requested profile "no-ui-tests-on-mac" could not be activated because it does not exist.
[WARNING] The requested profile "ui-tests-locally" could not be activated because it does not exist.
[ERROR] Failed to execute goal org.revapi:revapi-maven-plugin:0.14.7:check (default-cli) on project codingstyle: Failed to execute the API analysis.: Failed to analyze archives: Could not convert the configuration. Schema:
[ERROR] {
[ERROR]   "oneOf" : [ {
[ERROR]     "$ref" : "#/definitions/allows"
[ERROR]   }, {
[ERROR]     "type" : "array",
[ERROR]     "items" : {
[ERROR]       "$ref" : "#/definitions/allows"
[ERROR]     }
[ERROR]   } ]
[ERROR] }
[ERROR] 
[ERROR] Data:
[ERROR] org.revapi.maven.AnalysisConfigurationGatherer$PlexusConfigurationWrapper@565d7d2f
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```