### PR TITLE
Revapi JMPS compilation support

### DIFF
--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2023 Lukas Krejci
+    Copyright 2014-2025 Lukas Krejci
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -113,6 +113,12 @@
                             <goal>report-aggregate</goal>
                         </goals>
                         <phase>verify</phase>
+                        <configuration>
+                            <!-- Exclude alternate versions for multi-release modules due to https://github.com/jacoco/jacoco/issues/407 -->
+                            <excludes>
+                                <exclude>META-INF/**/*</exclude>
+                            </excludes>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/revapi-build/pom.xml
+++ b/revapi-build/pom.xml
@@ -51,8 +51,8 @@
             Work around Intellij's lack for maven.compiler.release attribute
             See https://youtrack.jetbrains.com/issue/IDEA-173143
 	-->
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <self-api-check.java-extension-version>0.28.1</self-api-check.java-extension-version>
         <self-api-check.maven-version>0.15.0</self-api-check.maven-version>
@@ -172,6 +172,10 @@
                         </goals>
                         <phase>test</phase>
                         <configuration>
+                            <!-- Exclude alternate versions for multi-release modules due to https://github.com/jacoco/jacoco/issues/407 -->
+                            <excludes>
+                                <exclude>META-INF/**/*</exclude>
+                            </excludes>
                             <dataFile>${project.build.directory}/jacoco-ut.exec</dataFile>
                         </configuration>
                     </execution>
@@ -398,13 +402,13 @@
                 <jdk>[9,]</jdk>
             </activation>
             <properties>
-                <maven.compiler.release>17</maven.compiler.release>
+                <maven.compiler.release>8</maven.compiler.release>
             </properties>
         </profile>
         <profile>
             <id>java8</id>
             <activation>
-                <jdk>[,17]</jdk>
+                <jdk>[,1.8]</jdk>
             </activation>
             <build>
                 <plugins>

--- a/revapi-build/pom.xml
+++ b/revapi-build/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2023 Lukas Krejci
+    Copyright 2014-2025 Lukas Krejci
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,8 +51,8 @@
             Work around Intellij's lack for maven.compiler.release attribute
             See https://youtrack.jetbrains.com/issue/IDEA-173143
 	-->
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <self-api-check.java-extension-version>0.28.1</self-api-check.java-extension-version>
         <self-api-check.maven-version>0.15.0</self-api-check.maven-version>
@@ -398,13 +398,13 @@
                 <jdk>[9,]</jdk>
             </activation>
             <properties>
-                <maven.compiler.release>8</maven.compiler.release>
+                <maven.compiler.release>17</maven.compiler.release>
             </properties>
         </profile>
         <profile>
             <id>java8</id>
             <activation>
-                <jdk>[,1.8]</jdk>
+                <jdk>[,17]</jdk>
             </activation>
             <build>
                 <plugins>

--- a/revapi-java-spi/pom.xml
+++ b/revapi-java-spi/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2014-2022 Lukas Krejci
+    Copyright 2014-2025 Lukas Krejci
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,7 +44,6 @@
     </distributionManagement>
     <properties>
         <automatic.module.name>org.revapi.java.spi</automatic.module.name>
-        <jacoco.skip>true</jacoco.skip>
     </properties>
     <dependencies>
         <dependency>

--- a/revapi-java/pom.xml
+++ b/revapi-java/pom.xml
@@ -153,6 +153,22 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Multi-Release>true</Multi-Release>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <execution>

--- a/revapi-java/src/main/java-mr/9/org/revapi/java/compilation/Compiler.java
+++ b/revapi-java/src/main/java-mr/9/org/revapi/java/compilation/Compiler.java
@@ -68,8 +68,8 @@ public final class Compiler {
     private final Iterable<JarExtractor> jarExtractors;
 
     public Compiler(ExecutorService executor, Writer reportingOutput, Iterable<JarExtractor> jarExtractors,
-            Iterable<? extends Archive> classPath, Iterable<? extends Archive> additionalClassPath,
-            TreeFilter<JavaElement> filter) {
+                    Iterable<? extends Archive> classPath, Iterable<? extends Archive> additionalClassPath,
+                    TreeFilter<JavaElement> filter) {
         this.jarExtractors = jarExtractors;
 
         compiler = ToolProvider.getSystemJavaCompiler();
@@ -85,8 +85,8 @@ public final class Compiler {
     }
 
     public CompilationValve compile(final ProbingEnvironment environment,
-            final AnalysisConfiguration.MissingClassReporting missingClassReporting,
-            final boolean ignoreMissingAnnotations) throws Exception {
+                                    final AnalysisConfiguration.MissingClassReporting missingClassReporting,
+                                    final boolean ignoreMissingAnnotations) throws Exception {
 
         File targetPath = Files.createTempDirectory("revapi-java").toAbsolutePath().toFile();
 
@@ -106,7 +106,8 @@ public final class Compiler {
         IdentityHashMap<Archive, File> additionClassPathFiles = copyArchives(additionalClassPath, lib, classPathSize,
                 prefixLength);
 
-        List<String> options = Arrays.asList("-d", sourceDir.toString(), "-cp", composeClassPath(lib));
+        List<String> options = Arrays.asList("-d", sourceDir.toString(), "--module-path", lib.getAbsolutePath(),
+                "--add-modules", "ALL-MODULE-PATH");
 
         List<JavaFileObject> sources = Arrays.<JavaFileObject> asList(new MarkerAnnotationObject(),
                 new ArchiveProbeObject());
@@ -172,7 +173,7 @@ public final class Compiler {
     }
 
     private IdentityHashMap<Archive, File> copyArchives(Iterable<? extends Archive> archives, File parentDir,
-            int startIdx, int prefixLength) {
+                                                        int startIdx, int prefixLength) {
         IdentityHashMap<Archive, File> ret = new IdentityHashMap<>();
         if (archives == null) {
             return ret;
@@ -231,7 +232,8 @@ public final class Compiler {
 
     private String formatName(int idx, int prefixLength, String rootName) {
         try {
-            return String.format("%0" + prefixLength + "d-%s", idx, UUID.nameUUIDFromBytes(rootName.getBytes("UTF-8")));
+            return String.format("%0" + prefixLength + "d-%s.jar", idx,
+                    UUID.nameUUIDFromBytes(rootName.getBytes("UTF-8")));
         } catch (UnsupportedEncodingException e) {
             throw new IllegalStateException("UTF-8 not supported.");
         }

--- a/revapi-java/src/main/java-mr/9/org/revapi/java/compilation/MissingTypeAwareDelegatingElements.java
+++ b/revapi-java/src/main/java-mr/9/org/revapi/java/compilation/MissingTypeAwareDelegatingElements.java
@@ -24,6 +24,7 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.ModuleElement;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
@@ -122,5 +123,10 @@ final class MissingTypeAwareDelegatingElements implements Elements {
         } catch (Exception ex) {
             throw new IllegalStateException(ex);
         }
+    }
+
+    @Override
+    public ModuleElement getModuleOf(Element e) {
+        return elements.getModuleOf(e);
     }
 }

--- a/revapi-java/src/main/java/org/revapi/java/compilation/ClasspathScanner.java
+++ b/revapi-java/src/main/java/org/revapi/java/compilation/ClasspathScanner.java
@@ -231,7 +231,6 @@ final class ClasspathScanner {
 
         SyntheticLocation allLoc = new SyntheticLocation();
         fileManager.setLocation(allLoc, classPath.values());
-        fileManager.setLocation(allLoc, additionalClassPath.values());
 
         Function<String, JavaFileObject> searchHard = className -> Stream
                 .concat(Stream.of(allLoc), Stream.of(POSSIBLE_SYSTEM_CLASS_LOCATIONS)).map(l -> {

--- a/revapi-java/src/main/java/org/revapi/java/compilation/ClasspathScanner.java
+++ b/revapi-java/src/main/java/org/revapi/java/compilation/ClasspathScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -231,6 +231,7 @@ final class ClasspathScanner {
 
         SyntheticLocation allLoc = new SyntheticLocation();
         fileManager.setLocation(allLoc, classPath.values());
+        fileManager.setLocation(allLoc, additionalClassPath.values());
 
         Function<String, JavaFileObject> searchHard = className -> Stream
                 .concat(Stream.of(allLoc), Stream.of(POSSIBLE_SYSTEM_CLASS_LOCATIONS)).map(l -> {

--- a/revapi-java/src/main/java/org/revapi/java/compilation/Compiler.java
+++ b/revapi-java/src/main/java/org/revapi/java/compilation/Compiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -106,7 +106,8 @@ public final class Compiler {
         IdentityHashMap<Archive, File> additionClassPathFiles = copyArchives(additionalClassPath, lib, classPathSize,
                 prefixLength);
 
-        List<String> options = Arrays.asList("-d", sourceDir.toString(), "-cp", composeClassPath(lib));
+        List<String> options = Arrays.asList("-d", sourceDir.toString(), "--module-path", lib.getAbsolutePath(),
+                "--add-modules", "ALL-MODULE-PATH");
 
         List<JavaFileObject> sources = Arrays.<JavaFileObject> asList(new MarkerAnnotationObject(),
                 new ArchiveProbeObject());
@@ -231,7 +232,8 @@ public final class Compiler {
 
     private String formatName(int idx, int prefixLength, String rootName) {
         try {
-            return String.format("%0" + prefixLength + "d-%s", idx, UUID.nameUUIDFromBytes(rootName.getBytes("UTF-8")));
+            return String.format("%0" + prefixLength + "d-%s.jar", idx,
+                    UUID.nameUUIDFromBytes(rootName.getBytes("UTF-8")));
         } catch (UnsupportedEncodingException e) {
             throw new IllegalStateException("UTF-8 not supported.");
         }

--- a/revapi-java/src/main/java/org/revapi/java/compilation/MissingTypeAwareDelegatingElements.java
+++ b/revapi-java/src/main/java/org/revapi/java/compilation/MissingTypeAwareDelegatingElements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,7 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.ModuleElement;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
@@ -122,5 +123,10 @@ final class MissingTypeAwareDelegatingElements implements Elements {
         } catch (Exception ex) {
             throw new IllegalStateException(ex);
         }
+    }
+
+    @Override
+    public ModuleElement getModuleOf(Element e) {
+        return elements.getModuleOf(e);
     }
 }

--- a/revapi-java/src/test/java/org/revapi/java/JavaArchiveAnalyzerTest.java
+++ b/revapi-java/src/test/java/org/revapi/java/JavaArchiveAnalyzerTest.java
@@ -87,7 +87,7 @@ public class JavaArchiveAnalyzerTest extends AbstractJavaElementAnalyzerTest {
     @Test
     public void testWithSupplementary() throws Exception {
         ArchiveAndCompilationPath compRes = createCompiledJar("a.jar", "v1/supplementary/a/A.java",
-                "v1/supplementary/b/B.java", "v1/supplementary/a/C.java");
+                "v1/supplementary/b/B.java", "v1/supplementary/b/D.java");
 
         JavaArchive api = ShrinkWrap.create(JavaArchive.class, "api.jar")
                 .addAsResource(compRes.compilationPath.resolve(A_PACKAGE_PATH + "A.class").toFile(),
@@ -103,8 +103,9 @@ public class JavaArchiveAnalyzerTest extends AbstractJavaElementAnalyzerTest {
                         SUP_PACKAGE_PATH + "B$T$1$TT$1.class")
                 .addAsResource(compRes.compilationPath.resolve(SUP_PACKAGE_PATH + "B$T$2.class").toFile(),
                         SUP_PACKAGE_PATH + "B$T$2.class")
-                .addAsResource(compRes.compilationPath.resolve(SUP_PACKAGE_PATH + "C.class").toFile(),
-                        SUP_PACKAGE_PATH + "C.class")
+                // Change to D because this is used in the api in SupplementaryJarsTest (split package fixes)
+                .addAsResource(compRes.compilationPath.resolve(SUP_PACKAGE_PATH + "D.class").toFile(),
+                        SUP_PACKAGE_PATH + "D.class")
                 .addAsResource(
                         compRes.compilationPath.resolve(SUP_PACKAGE_PATH + "B$UsedByIgnoredClass.class").toFile(),
                         SUP_PACKAGE_PATH + "B$UsedByIgnoredClass.class");

--- a/revapi-java/src/test/java/org/revapi/java/JavaArchiveAnalyzerTest.java
+++ b/revapi-java/src/test/java/org/revapi/java/JavaArchiveAnalyzerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,6 +56,8 @@ import org.revapi.java.spi.UseSite;
  * @since 0.1
  */
 public class JavaArchiveAnalyzerTest extends AbstractJavaElementAnalyzerTest {
+    public static final String A_PACKAGE_PATH = "a/";
+    public static final String SUP_PACKAGE_PATH = "sup/";
     private JavaApiAnalyzer apiAnalyzer;
 
     @Before
@@ -88,16 +90,24 @@ public class JavaArchiveAnalyzerTest extends AbstractJavaElementAnalyzerTest {
                 "v1/supplementary/b/B.java", "v1/supplementary/a/C.java");
 
         JavaArchive api = ShrinkWrap.create(JavaArchive.class, "api.jar")
-                .addAsResource(compRes.compilationPath.resolve("A.class").toFile(), "A.class");
+                .addAsResource(compRes.compilationPath.resolve(A_PACKAGE_PATH + "A.class").toFile(),
+                        A_PACKAGE_PATH + "A.class")
+                .addAsResource(compRes.compilationPath.resolve(A_PACKAGE_PATH + "A$PrivateEnum.class").toFile(),
+                        A_PACKAGE_PATH + "A$PrivateEnum.class");
         JavaArchive sup = ShrinkWrap.create(JavaArchive.class, "sup.jar")
-                .addAsResource(compRes.compilationPath.resolve("B.class").toFile(), "B.class")
-                .addAsResource(compRes.compilationPath.resolve("B$T$1.class").toFile(), "B$T$1.class")
-                .addAsResource(compRes.compilationPath.resolve("B$T$1$TT$1.class").toFile(), "B$T$1$TT$1.class")
-                .addAsResource(compRes.compilationPath.resolve("B$T$2.class").toFile(), "B$T$2.class")
-                .addAsResource(compRes.compilationPath.resolve("C.class").toFile(), "C.class")
-                .addAsResource(compRes.compilationPath.resolve("B$UsedByIgnoredClass.class").toFile(),
-                        "B$UsedByIgnoredClass.class")
-                .addAsResource(compRes.compilationPath.resolve("A$PrivateEnum.class").toFile(), "A$PrivateEnum.class");
+                .addAsResource(compRes.compilationPath.resolve(SUP_PACKAGE_PATH + "B.class").toFile(),
+                        SUP_PACKAGE_PATH + "B.class")
+                .addAsResource(compRes.compilationPath.resolve(SUP_PACKAGE_PATH + "B$T$1.class").toFile(),
+                        SUP_PACKAGE_PATH + "B$T$1.class")
+                .addAsResource(compRes.compilationPath.resolve(SUP_PACKAGE_PATH + "B$T$1$TT$1.class").toFile(),
+                        SUP_PACKAGE_PATH + "B$T$1$TT$1.class")
+                .addAsResource(compRes.compilationPath.resolve(SUP_PACKAGE_PATH + "B$T$2.class").toFile(),
+                        SUP_PACKAGE_PATH + "B$T$2.class")
+                .addAsResource(compRes.compilationPath.resolve(SUP_PACKAGE_PATH + "C.class").toFile(),
+                        SUP_PACKAGE_PATH + "C.class")
+                .addAsResource(
+                        compRes.compilationPath.resolve(SUP_PACKAGE_PATH + "B$UsedByIgnoredClass.class").toFile(),
+                        SUP_PACKAGE_PATH + "B$UsedByIgnoredClass.class");
 
         JavaArchiveAnalyzer analyzer = new JavaArchiveAnalyzer(apiAnalyzer,
                 new API(Arrays.asList(new ShrinkwrapArchive(api)), Arrays.asList(new ShrinkwrapArchive(sup))),
@@ -115,12 +125,12 @@ public class JavaArchiveAnalyzerTest extends AbstractJavaElementAnalyzerTest {
             TypeElement B_T$1 = roots.next().as(TypeElement.class);
             TypeElement B_T$2 = roots.next().as(TypeElement.class);
 
-            Assert.assertEquals("A", A.getCanonicalName());
-            Assert.assertEquals("A", A.getDeclaringElement().getQualifiedName().toString());
-            Assert.assertEquals("B.T$1", B_T$1.getCanonicalName());
-            Assert.assertEquals("B.T$1", B_T$1.getDeclaringElement().getQualifiedName().toString());
-            Assert.assertEquals("B.T$2", B_T$2.getCanonicalName());
-            Assert.assertEquals("B.T$2", B_T$2.getDeclaringElement().getQualifiedName().toString());
+            Assert.assertEquals("a.A", A.getCanonicalName());
+            Assert.assertEquals("a.A", A.getDeclaringElement().getQualifiedName().toString());
+            Assert.assertEquals("sup.B.T$1", B_T$1.getCanonicalName());
+            Assert.assertEquals("sup.B.T$1", B_T$1.getDeclaringElement().getQualifiedName().toString());
+            Assert.assertEquals("sup.B.T$2", B_T$2.getCanonicalName());
+            Assert.assertEquals("sup.B.T$2", B_T$2.getDeclaringElement().getQualifiedName().toString());
         } finally {
             deleteDir(compRes.compilationPath);
             analyzer.getCompilationValve().removeCompiledResults();
@@ -173,24 +183,31 @@ public class JavaArchiveAnalyzerTest extends AbstractJavaElementAnalyzerTest {
         ArchiveAndCompilationPath compRes = createCompiledJar("a.jar", "misc/Generics.java",
                 "misc/GenericsParams.java");
 
-        JavaArchive api = ShrinkWrap.create(JavaArchive.class, "api.jar")
-                .addAsResource(compRes.compilationPath.resolve("Generics.class").toFile(), "Generics.class");
+        JavaArchive api = ShrinkWrap.create(JavaArchive.class, "api.jar").addAsResource(
+                compRes.compilationPath.resolve(A_PACKAGE_PATH + "Generics.class").toFile(),
+                A_PACKAGE_PATH + "Generics.class");
         JavaArchive sup = ShrinkWrap.create(JavaArchive.class, "sup.jar")
-                .addAsResource(compRes.compilationPath.resolve("GenericsParams.class").toFile(), "GenericsParams.class")
-                .addAsResource(compRes.compilationPath.resolve("GenericsParams$TypeParam.class").toFile(),
-                        "GenericsParams$TypeParam.class")
-                .addAsResource(compRes.compilationPath.resolve("GenericsParams$ExtendsBound.class").toFile(),
-                        "GenericsParams$ExtendsBound.class")
-                .addAsResource(compRes.compilationPath.resolve("GenericsParams$SuperBound.class").toFile(),
-                        "GenericsParams$SuperBound.class")
-                .addAsResource(compRes.compilationPath.resolve("GenericsParams$TypeVar.class").toFile(),
-                        "GenericsParams$TypeVar.class")
-                .addAsResource(compRes.compilationPath.resolve("GenericsParams$TypeVarIface.class").toFile(),
-                        "GenericsParams$TypeVarIface.class")
-                .addAsResource(compRes.compilationPath.resolve("GenericsParams$TypeVarImpl.class").toFile(),
-                        "GenericsParams$TypeVarImpl.class")
-                .addAsResource(compRes.compilationPath.resolve("GenericsParams$Unused.class").toFile(),
-                        "GenericsParams$Unused.class");
+                .addAsResource(compRes.compilationPath.resolve(SUP_PACKAGE_PATH + "GenericsParams.class").toFile(),
+                        SUP_PACKAGE_PATH + "GenericsParams.class")
+                .addAsResource(
+                        compRes.compilationPath.resolve(SUP_PACKAGE_PATH + "GenericsParams$TypeParam.class").toFile(),
+                        SUP_PACKAGE_PATH + "GenericsParams$TypeParam.class")
+                .addAsResource(compRes.compilationPath.resolve(SUP_PACKAGE_PATH + "GenericsParams$ExtendsBound.class")
+                        .toFile(), SUP_PACKAGE_PATH + "GenericsParams$ExtendsBound.class")
+                .addAsResource(
+                        compRes.compilationPath.resolve(SUP_PACKAGE_PATH + "GenericsParams$SuperBound.class").toFile(),
+                        SUP_PACKAGE_PATH + "GenericsParams$SuperBound.class")
+                .addAsResource(
+                        compRes.compilationPath.resolve(SUP_PACKAGE_PATH + "GenericsParams$TypeVar.class").toFile(),
+                        SUP_PACKAGE_PATH + "GenericsParams$TypeVar.class")
+                .addAsResource(compRes.compilationPath.resolve(SUP_PACKAGE_PATH + "GenericsParams$TypeVarIface.class")
+                        .toFile(), SUP_PACKAGE_PATH + "GenericsParams$TypeVarIface.class")
+                .addAsResource(
+                        compRes.compilationPath.resolve(SUP_PACKAGE_PATH + "GenericsParams$TypeVarImpl.class").toFile(),
+                        SUP_PACKAGE_PATH + "GenericsParams$TypeVarImpl.class")
+                .addAsResource(
+                        compRes.compilationPath.resolve(SUP_PACKAGE_PATH + "GenericsParams$Unused.class").toFile(),
+                        SUP_PACKAGE_PATH + "GenericsParams$Unused.class");
 
         JavaArchiveAnalyzer analyzer = new JavaArchiveAnalyzer(apiAnalyzer,
                 new API(Arrays.asList(new ShrinkwrapArchive(api)), Arrays.asList(new ShrinkwrapArchive(sup))),
@@ -204,14 +221,14 @@ public class JavaArchiveAnalyzerTest extends AbstractJavaElementAnalyzerTest {
 
             Assert.assertEquals(7, roots.size());
             Assert.assertTrue(roots.stream().anyMatch(hasName(
-                    "class Generics<T extends GenericsParams.TypeVar & GenericsParams.TypeVarIface, U extends Generics<GenericsParams.TypeVarImpl, ?>>")));
-            Assert.assertTrue(roots.stream().anyMatch(hasName("class GenericsParams.ExtendsBound")));
-            Assert.assertTrue(roots.stream().anyMatch(hasName("class GenericsParams.SuperBound")));
-            Assert.assertTrue(roots.stream().anyMatch(hasName("class GenericsParams.TypeParam")));
-            Assert.assertTrue(roots.stream().anyMatch(hasName("class GenericsParams.TypeVar")));
-            Assert.assertTrue(roots.stream().anyMatch(hasName("interface GenericsParams.TypeVarIface")));
-            Assert.assertTrue(roots.stream().anyMatch(hasName("class GenericsParams.TypeVarImpl")));
-            Assert.assertFalse(roots.stream().anyMatch(hasName("class GenericsParams.Unused")));
+                    "class a.Generics<T extends sup.GenericsParams.TypeVar & sup.GenericsParams.TypeVarIface, U extends a.Generics<sup.GenericsParams.TypeVarImpl, ?>>")));
+            Assert.assertTrue(roots.stream().anyMatch(hasName("class sup.GenericsParams.ExtendsBound")));
+            Assert.assertTrue(roots.stream().anyMatch(hasName("class sup.GenericsParams.SuperBound")));
+            Assert.assertTrue(roots.stream().anyMatch(hasName("class sup.GenericsParams.TypeParam")));
+            Assert.assertTrue(roots.stream().anyMatch(hasName("class sup.GenericsParams.TypeVar")));
+            Assert.assertTrue(roots.stream().anyMatch(hasName("interface sup.GenericsParams.TypeVarIface")));
+            Assert.assertTrue(roots.stream().anyMatch(hasName("class sup.GenericsParams.TypeVarImpl")));
+            Assert.assertFalse(roots.stream().anyMatch(hasName("class sup.GenericsParams.Unused")));
         } finally {
             deleteDir(compRes.compilationPath);
             analyzer.getCompilationValve().removeCompiledResults();

--- a/revapi-java/src/test/java/org/revapi/java/MissingClassReportingTest.java
+++ b/revapi-java/src/test/java/org/revapi/java/MissingClassReportingTest.java
@@ -182,7 +182,6 @@ public class MissingClassReportingTest extends AbstractJavaElementAnalyzerTest {
             JavaArchive a2 = ShrinkWrap.create(JavaArchive.class, "superTypeV2.jar").addAsResource(
                     v2.compilationPath.resolve(SUPER_TYPE_PACKAGE_PATH + "B.class").toFile(),
                     SUPER_TYPE_PACKAGE_PATH + "B.class");
-            ;
 
             API oldApi = API.of(new ShrinkwrapArchive(a1)).build();
             API newApi = API.of(new ShrinkwrapArchive(a2)).build();

--- a/revapi-java/src/test/java/org/revapi/java/SupplementaryJarsTest.java
+++ b/revapi-java/src/test/java/org/revapi/java/SupplementaryJarsTest.java
@@ -68,7 +68,6 @@ public class SupplementaryJarsTest extends AbstractJavaElementAnalyzerTest {
                         A_PACKAGE_PATH + "C.class")
                 .addAsResource(compRes1.compilationPath.resolve(A_PACKAGE_PATH + "A$PrivateEnum.class").toFile(),
                         A_PACKAGE_PATH + "A$PrivateEnum.class");
-        ;
 
         supV1 = ShrinkWrap.create(JavaArchive.class, "supV1.jar")
                 .addAsResource(compRes1.compilationPath.resolve(SUP_PACKAGE_PATH + "B.class").toFile(),

--- a/revapi-java/src/test/java/org/revapi/java/SupplementaryJarsTest.java
+++ b/revapi-java/src/test/java/org/revapi/java/SupplementaryJarsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,6 +46,9 @@ public class SupplementaryJarsTest extends AbstractJavaElementAnalyzerTest {
     private JavaArchive supV1;
     private JavaArchive supV2;
 
+    public static final String A_PACKAGE_PATH = "a/";
+    public static final String SUP_PACKAGE_PATH = "sup/";
+
     @Before
     public void compile() throws Exception {
         // compile all the classes we need in 1 go
@@ -59,40 +62,61 @@ public class SupplementaryJarsTest extends AbstractJavaElementAnalyzerTest {
         // in public/protected fields/methods/method params are then considered the part of the API during api checks.
 
         apiV1 = ShrinkWrap.create(JavaArchive.class, "apiV1.jar")
-                .addAsResource(compRes1.compilationPath.resolve("A.class").toFile(), "A.class")
-                .addAsResource(compRes1.compilationPath.resolve("C.class").toFile(), "C.class");
+                .addAsResource(compRes1.compilationPath.resolve(A_PACKAGE_PATH + "A.class").toFile(),
+                        A_PACKAGE_PATH + "A.class")
+                .addAsResource(compRes1.compilationPath.resolve(A_PACKAGE_PATH + "C.class").toFile(),
+                        A_PACKAGE_PATH + "C.class")
+                .addAsResource(compRes1.compilationPath.resolve(A_PACKAGE_PATH + "A$PrivateEnum.class").toFile(),
+                        A_PACKAGE_PATH + "A$PrivateEnum.class");
+        ;
 
         supV1 = ShrinkWrap.create(JavaArchive.class, "supV1.jar")
-                .addAsResource(compRes1.compilationPath.resolve("B.class").toFile(), "B.class")
-                .addAsResource(compRes1.compilationPath.resolve("B$T$1.class").toFile(), "B$T$1.class")
-                .addAsResource(compRes1.compilationPath.resolve("B$T$1$TT$1.class").toFile(), "B$T$1$TT$1.class")
-                .addAsResource(compRes1.compilationPath.resolve("B$T$2.class").toFile(), "B$T$2.class")
-                .addAsResource(compRes1.compilationPath.resolve("B$UsedByIgnoredClass.class").toFile(),
-                        "B$UsedByIgnoredClass.class")
-                .addAsResource(compRes1.compilationPath.resolve("A$PrivateEnum.class").toFile(), "A$PrivateEnum.class");
+                .addAsResource(compRes1.compilationPath.resolve(SUP_PACKAGE_PATH + "B.class").toFile(),
+                        SUP_PACKAGE_PATH + "B.class")
+                .addAsResource(compRes1.compilationPath.resolve(SUP_PACKAGE_PATH + "B$T$1.class").toFile(),
+                        SUP_PACKAGE_PATH + "B$T$1.class")
+                .addAsResource(compRes1.compilationPath.resolve(SUP_PACKAGE_PATH + "B$T$1$TT$1.class").toFile(),
+                        SUP_PACKAGE_PATH + "B$T$1$TT$1.class")
+                .addAsResource(compRes1.compilationPath.resolve(SUP_PACKAGE_PATH + "B$T$2.class").toFile(),
+                        SUP_PACKAGE_PATH + "B$T$2.class")
+                .addAsResource(
+                        compRes1.compilationPath.resolve(SUP_PACKAGE_PATH + "B$UsedByIgnoredClass.class").toFile(),
+                        SUP_PACKAGE_PATH + "B$UsedByIgnoredClass.class");
 
         // now do the same for v2
         compRes2 = createCompiledJar("tmp2", "v2/supplementary/a/A.java", "v2/supplementary/b/B.java",
                 "v2/supplementary/a/C.java");
 
         apiV2 = ShrinkWrap.create(JavaArchive.class, "apiV2.jar")
-                .addAsResource(compRes2.compilationPath.resolve("A.class").toFile(), "A.class")
-                .addAsResource(compRes2.compilationPath.resolve("C.class").toFile(), "C.class");
+                .addAsResource(compRes2.compilationPath.resolve(A_PACKAGE_PATH + "A.class").toFile(),
+                        A_PACKAGE_PATH + "A.class")
+                .addAsResource(compRes2.compilationPath.resolve(A_PACKAGE_PATH + "C.class").toFile(),
+                        A_PACKAGE_PATH + "C.class")
+                .addAsResource(compRes2.compilationPath.resolve(A_PACKAGE_PATH + "A$PrivateEnum.class").toFile(),
+                        A_PACKAGE_PATH + "A$PrivateEnum.class");
         supV2 = ShrinkWrap.create(JavaArchive.class, "supV2.jar")
-                .addAsResource(compRes2.compilationPath.resolve("B.class").toFile(), "B.class")
-                .addAsResource(compRes2.compilationPath.resolve("B$T$1.class").toFile(), "B$T$1.class")
-                .addAsResource(compRes2.compilationPath.resolve("B$T$1$TT$1.class").toFile(), "B$T$1$TT$1.class")
-                .addAsResource(compRes2.compilationPath.resolve("B$T$2.class").toFile(), "B$T$2.class")
-                .addAsResource(compRes2.compilationPath.resolve("B$T$1$Private.class").toFile(), "B$T$1$Private.class")
-                .addAsResource(compRes2.compilationPath.resolve("B$T$3.class").toFile(), "B$T$3.class")
-                .addAsResource(compRes2.compilationPath.resolve("B$PrivateSuperClass.class").toFile(),
-                        "B$PrivateSuperClass.class")
-                .addAsResource(compRes2.compilationPath.resolve("B$PrivateUsedClass.class").toFile(),
-                        "B$PrivateUsedClass.class")
-                .addAsResource(compRes2.compilationPath.resolve("B$UsedByIgnoredClass.class").toFile(),
-                        "B$UsedByIgnoredClass.class")
-                .addAsResource(compRes2.compilationPath.resolve("A$PrivateEnum.class").toFile(), "A$PrivateEnum.class")
-                .addAsResource(compRes2.compilationPath.resolve("B$PrivateBase.class").toFile(), "B$PrivateBase.class");
+                .addAsResource(compRes2.compilationPath.resolve(SUP_PACKAGE_PATH + "B.class").toFile(),
+                        SUP_PACKAGE_PATH + "B.class")
+                .addAsResource(compRes2.compilationPath.resolve(SUP_PACKAGE_PATH + "B$T$1.class").toFile(),
+                        SUP_PACKAGE_PATH + "B$T$1.class")
+                .addAsResource(compRes2.compilationPath.resolve(SUP_PACKAGE_PATH + "B$T$1$TT$1.class").toFile(),
+                        SUP_PACKAGE_PATH + "B$T$1$TT$1.class")
+                .addAsResource(compRes2.compilationPath.resolve(SUP_PACKAGE_PATH + "B$T$2.class").toFile(),
+                        SUP_PACKAGE_PATH + "B$T$2.class")
+                .addAsResource(compRes2.compilationPath.resolve(SUP_PACKAGE_PATH + "B$T$1$Private.class").toFile(),
+                        SUP_PACKAGE_PATH + "B$T$1$Private.class")
+                .addAsResource(compRes2.compilationPath.resolve(SUP_PACKAGE_PATH + "B$T$3.class").toFile(),
+                        SUP_PACKAGE_PATH + "B$T$3.class")
+                .addAsResource(
+                        compRes2.compilationPath.resolve(SUP_PACKAGE_PATH + "B$PrivateSuperClass.class").toFile(),
+                        SUP_PACKAGE_PATH + "B$PrivateSuperClass.class")
+                .addAsResource(compRes2.compilationPath.resolve(SUP_PACKAGE_PATH + "B$PrivateUsedClass.class").toFile(),
+                        SUP_PACKAGE_PATH + "B$PrivateUsedClass.class")
+                .addAsResource(
+                        compRes2.compilationPath.resolve(SUP_PACKAGE_PATH + "B$UsedByIgnoredClass.class").toFile(),
+                        SUP_PACKAGE_PATH + "B$UsedByIgnoredClass.class")
+                .addAsResource(compRes2.compilationPath.resolve(SUP_PACKAGE_PATH + "B$PrivateBase.class").toFile(),
+                        SUP_PACKAGE_PATH + "B$PrivateBase.class");
     }
 
     @After
@@ -118,20 +142,21 @@ public class SupplementaryJarsTest extends AbstractJavaElementAnalyzerTest {
         }
 
         Assert.assertEquals(8, allReports.size());
-        Assert.assertTrue(
-                containsDifference(allReports, null, "class B.T$1.Private", Code.CLASS_NON_PUBLIC_PART_OF_API.code()));
-        Assert.assertTrue(containsDifference(allReports, null, "field B.T$2.f2", Code.FIELD_ADDED.code()));
-        Assert.assertTrue(containsDifference(allReports, null, "field A.f3", Code.FIELD_ADDED.code()));
-        Assert.assertTrue(containsDifference(allReports, "class B.T$2", "class B.T$2", Code.CLASS_NOW_FINAL.code()));
-        Assert.assertTrue(
-                containsDifference(allReports, null, "class B.T$3", Code.CLASS_EXTERNAL_CLASS_EXPOSED_IN_API.code()));
-        Assert.assertTrue(containsDifference(allReports, null, "class B.PrivateUsedClass",
+        Assert.assertTrue(containsDifference(allReports, null, "class sup.B.T$1.Private",
                 Code.CLASS_NON_PUBLIC_PART_OF_API.code()));
-        Assert.assertTrue(containsDifference(allReports, "class B.UsedByIgnoredClass", "interface B.UsedByIgnoredClass",
-                Code.CLASS_KIND_CHANGED.code()));
-        Assert.assertTrue(containsDifference(allReports, "class B.UsedByIgnoredClass", "interface B.UsedByIgnoredClass",
-                Code.CLASS_NOW_ABSTRACT.code()));
-        Assert.assertTrue(containsDifference(allReports, "method void B.UsedByIgnoredClass::<init>()", null,
+        Assert.assertTrue(containsDifference(allReports, null, "field sup.B.T$2.f2", Code.FIELD_ADDED.code()));
+        Assert.assertTrue(containsDifference(allReports, null, "field a.A.f3", Code.FIELD_ADDED.code()));
+        Assert.assertTrue(
+                containsDifference(allReports, "class sup.B.T$2", "class sup.B.T$2", Code.CLASS_NOW_FINAL.code()));
+        Assert.assertTrue(containsDifference(allReports, null, "class sup.B.T$3",
+                Code.CLASS_EXTERNAL_CLASS_EXPOSED_IN_API.code()));
+        Assert.assertTrue(containsDifference(allReports, null, "class sup.B.PrivateUsedClass",
+                Code.CLASS_NON_PUBLIC_PART_OF_API.code()));
+        Assert.assertTrue(containsDifference(allReports, "class sup.B.UsedByIgnoredClass",
+                "interface sup.B.UsedByIgnoredClass", Code.CLASS_KIND_CHANGED.code()));
+        Assert.assertTrue(containsDifference(allReports, "class sup.B.UsedByIgnoredClass",
+                "interface sup.B.UsedByIgnoredClass", Code.CLASS_NOW_ABSTRACT.code()));
+        Assert.assertTrue(containsDifference(allReports, "method void sup.B.UsedByIgnoredClass::<init>()", null,
                 Code.METHOD_REMOVED.code()));
     }
 
@@ -144,7 +169,7 @@ public class SupplementaryJarsTest extends AbstractJavaElementAnalyzerTest {
                 .withOldAPI(API.of(new ShrinkwrapArchive(apiV1)).supportedBy(new ShrinkwrapArchive(supV1)).build())
                 .withNewAPI(API.of(new ShrinkwrapArchive(apiV2)).supportedBy(new ShrinkwrapArchive(supV2)).build())
                 .withConfigurationFromJSON("{\"revapi\": {\"filter\": {"
-                        + "\"elements\": {\"exclude\": [{\"matcher\": \"java\", \"match\": \"class C {}\"}]}}}}")
+                        + "\"elements\": {\"exclude\": [{\"matcher\": \"java\", \"match\": \"class a.C {}\"}]}}}}")
                 .build();
 
         try (AnalysisResult res = revapi.analyze(ctx)) {
@@ -153,18 +178,19 @@ public class SupplementaryJarsTest extends AbstractJavaElementAnalyzerTest {
         }
 
         Assert.assertEquals(6, allReports.size());
-        Assert.assertTrue(
-                containsDifference(allReports, null, "class B.T$1.Private", Code.CLASS_NON_PUBLIC_PART_OF_API.code()));
-        Assert.assertTrue(containsDifference(allReports, null, "field B.T$2.f2", Code.FIELD_ADDED.code()));
-        Assert.assertTrue(containsDifference(allReports, null, "field A.f3", Code.FIELD_ADDED.code()));
-        Assert.assertTrue(containsDifference(allReports, "class B.T$2", "class B.T$2", Code.CLASS_NOW_FINAL.code()));
-        Assert.assertTrue(
-                containsDifference(allReports, null, "class B.T$3", Code.CLASS_EXTERNAL_CLASS_EXPOSED_IN_API.code()));
-        Assert.assertTrue(containsDifference(allReports, null, "class B.PrivateUsedClass",
+        Assert.assertTrue(containsDifference(allReports, null, "class sup.B.T$1.Private",
                 Code.CLASS_NON_PUBLIC_PART_OF_API.code()));
-        Assert.assertFalse(containsDifference(allReports, "class B.UsedByIgnoredClass", "class B.UsedByIgnoredClass",
-                Code.CLASS_KIND_CHANGED.code()));
-        Assert.assertFalse(containsDifference(allReports, "method void B.UsedByIgnoredClass::<init>()", null,
+        Assert.assertTrue(containsDifference(allReports, null, "field sup.B.T$2.f2", Code.FIELD_ADDED.code()));
+        Assert.assertTrue(containsDifference(allReports, null, "field a.A.f3", Code.FIELD_ADDED.code()));
+        Assert.assertTrue(
+                containsDifference(allReports, "class sup.B.T$2", "class sup.B.T$2", Code.CLASS_NOW_FINAL.code()));
+        Assert.assertTrue(containsDifference(allReports, null, "class sup.B.T$3",
+                Code.CLASS_EXTERNAL_CLASS_EXPOSED_IN_API.code()));
+        Assert.assertTrue(containsDifference(allReports, null, "class sup.B.PrivateUsedClass",
+                Code.CLASS_NON_PUBLIC_PART_OF_API.code()));
+        Assert.assertFalse(containsDifference(allReports, "class sup.B.UsedByIgnoredClass",
+                "class sup.B.UsedByIgnoredClass", Code.CLASS_KIND_CHANGED.code()));
+        Assert.assertFalse(containsDifference(allReports, "method void sup.B.UsedByIgnoredClass::<init>()", null,
                 Code.METHOD_REMOVED.code()));
     }
 
@@ -178,7 +204,7 @@ public class SupplementaryJarsTest extends AbstractJavaElementAnalyzerTest {
                 .withOldAPI(API.of(new ShrinkwrapArchive(apiV1)).supportedBy(new ShrinkwrapArchive(supV1)).build())
                 .withNewAPI(API.of(new ShrinkwrapArchive(apiV2)).supportedBy(new ShrinkwrapArchive(supV2)).build())
                 .withConfigurationFromJSON("{\"revapi\": {"
-                        + "\"filter\": {\"elements\": {\"exclude\": [{\"matcher\": \"java\", \"match\": \"match %c | %b; class %c=C {} class %b=B.T$2 {}\"}]}}}}")
+                        + "\"filter\": {\"elements\": {\"exclude\": [{\"matcher\": \"java\", \"match\": \"match %c | %b; class %c=a.C {} class %b=sup.B.T$2 {}\"}]}}}}")
                 .build();
 
         try (AnalysisResult res = revapi.analyze(ctx)) {
@@ -187,18 +213,19 @@ public class SupplementaryJarsTest extends AbstractJavaElementAnalyzerTest {
         }
 
         Assert.assertEquals(3, allReports.size());
-        Assert.assertFalse(
-                containsDifference(allReports, null, "class B.T$1.Private", Code.CLASS_NON_PUBLIC_PART_OF_API.code()));
-        Assert.assertFalse(containsDifference(allReports, null, "field B.T$2.f2", Code.FIELD_ADDED.code()));
-        Assert.assertTrue(containsDifference(allReports, null, "field A.f3", Code.FIELD_ADDED.code()));
-        Assert.assertFalse(containsDifference(allReports, "class B.T$2", "class B.T$2", Code.CLASS_NOW_FINAL.code()));
-        Assert.assertTrue(
-                containsDifference(allReports, null, "class B.T$3", Code.CLASS_EXTERNAL_CLASS_EXPOSED_IN_API.code()));
-        Assert.assertTrue(containsDifference(allReports, null, "class B.PrivateUsedClass",
+        Assert.assertFalse(containsDifference(allReports, null, "class sup.B.T$1.Private",
                 Code.CLASS_NON_PUBLIC_PART_OF_API.code()));
-        Assert.assertFalse(containsDifference(allReports, "class B.UsedByIgnoredClass", "class B.UsedByIgnoredClass",
-                Code.CLASS_KIND_CHANGED.code()));
-        Assert.assertFalse(containsDifference(allReports, "method void B.UsedByIgnoredClass::<init>()", null,
+        Assert.assertFalse(containsDifference(allReports, null, "field sup.B.T$2.f2", Code.FIELD_ADDED.code()));
+        Assert.assertTrue(containsDifference(allReports, null, "field a.A.f3", Code.FIELD_ADDED.code()));
+        Assert.assertFalse(
+                containsDifference(allReports, "classa. B.T$2", "class sup.B.T$2", Code.CLASS_NOW_FINAL.code()));
+        Assert.assertTrue(containsDifference(allReports, null, "class sup.B.T$3",
+                Code.CLASS_EXTERNAL_CLASS_EXPOSED_IN_API.code()));
+        Assert.assertTrue(containsDifference(allReports, null, "class sup.B.PrivateUsedClass",
+                Code.CLASS_NON_PUBLIC_PART_OF_API.code()));
+        Assert.assertFalse(containsDifference(allReports, "class sup.B.UsedByIgnoredClass",
+                "class sup.B.UsedByIgnoredClass", Code.CLASS_KIND_CHANGED.code()));
+        Assert.assertFalse(containsDifference(allReports, "method void sup.B.UsedByIgnoredClass::<init>()", null,
                 Code.METHOD_REMOVED.code()));
     }
 }

--- a/revapi-java/src/test/resources/misc/Generics.java
+++ b/revapi-java/src/test/resources/misc/Generics.java
@@ -1,4 +1,29 @@
 /*
+ * Copyright 2014-2025 Lukas Krejci
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package a;
+
+import sup.GenericsParams.ExtendsBound;
+import sup.GenericsParams.SuperBound;
+import sup.GenericsParams.TypeVar;
+import sup.GenericsParams.TypeVarIface;
+import sup.GenericsParams.TypeVarImpl;
+import sup.GenericsParams.TypeParam;
+
+/*
  * Copyright 2014-2017 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
@@ -14,15 +39,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-public class Generics<T extends GenericsParams.TypeVar & GenericsParams.TypeVarIface, U extends Generics<GenericsParams.TypeVarImpl, ?>> {
+public class Generics<T extends TypeVar & TypeVarIface, U extends Generics<TypeVarImpl, ?>> {
 
-    public java.util.Set<GenericsParams.TypeParam> field;
+    public java.util.Set<TypeParam> field;
 
     public <X extends U> X method1() {return null;}
 
-    public void method2(java.util.Set<? super GenericsParams.SuperBound> x) {}
+    public void method2(java.util.Set<? super SuperBound> x) {}
 
     public <X extends T> X method3() {return null;}
 
-    public <X extends GenericsParams.ExtendsBound> void method4(java.util.Set<X> x) {}
+    public <X extends ExtendsBound> void method4(java.util.Set<X> x) {}
 }

--- a/revapi-java/src/test/resources/misc/GenericsParams.java
+++ b/revapi-java/src/test/resources/misc/GenericsParams.java
@@ -1,4 +1,22 @@
 /*
+ * Copyright 2014-2025 Lukas Krejci
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sup;
+
+/*
  * Copyright 2014-2017 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *

--- a/revapi-java/src/test/resources/v1/supplementary/a/A.java
+++ b/revapi-java/src/test/resources/v1/supplementary/a/A.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,15 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package a;
+
 public class A {
-    private B.T$1 f1;
-    public B.T$2 f2;
+    private sup.B.T$1 f1;
+    public sup.B.T$2 f2;
 
     //this tests that a public field or method of a private class doesn't move it to API.
     private enum PrivateEnum {ONE, TWO}
 
     //this tests missing classes can be used as throws declarations, too
-    public void m() throws B.T$2 {
+    public void m() throws sup.B.T$2 {
 
     }
 }

--- a/revapi-java/src/test/resources/v1/supplementary/a/C.java
+++ b/revapi-java/src/test/resources/v1/supplementary/a/C.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package sup;
+package a;
 public class C {
     public sup.B.UsedByIgnoredClass field;
 }

--- a/revapi-java/src/test/resources/v1/supplementary/a/C.java
+++ b/revapi-java/src/test/resources/v1/supplementary/a/C.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package sup;
 public class C {
-    public B.UsedByIgnoredClass field;
+    public sup.B.UsedByIgnoredClass field;
 }

--- a/revapi-java/src/test/resources/v1/supplementary/b/B.java
+++ b/revapi-java/src/test/resources/v1/supplementary/b/B.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package sup;
+
 public class B {
 
     public static class UsedByIgnoredClass {}

--- a/revapi-java/src/test/resources/v1/supplementary/b/D.java
+++ b/revapi-java/src/test/resources/v1/supplementary/b/D.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2014-2025 Lukas Krejci
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sup;
+public class D {
+    public sup.B.UsedByIgnoredClass field;
+}

--- a/revapi-java/src/test/resources/v1/supplementary/superType/A.java
+++ b/revapi-java/src/test/resources/v1/supplementary/superType/A.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package superType;
+
 public class A {
 
 }

--- a/revapi-java/src/test/resources/v1/supplementary/superType/B.java
+++ b/revapi-java/src/test/resources/v1/supplementary/superType/B.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package superType;
+
 public class B extends A {
 
 }

--- a/revapi-java/src/test/resources/v2/supplementary/a/A.java
+++ b/revapi-java/src/test/resources/v2/supplementary/a/A.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,16 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package a;
+
 public class A {
-    private B.T$1 f1;
-    public B.T$2 f2;
-    public B.T$3 f3;
+    private sup.B.T$1 f1;
+    public sup.B.T$2 f2;
+    public sup.B.T$3 f3;
 
     //this tests that a public field or method of a private class doesn't move it to API.
     private enum PrivateEnum {ONE, TWO}
 
     //this tests missing classes can be used as throws declarations, too
-    public void m() throws B.T$2 {
+    public void m() throws sup.B.T$2 {
 
     }
 }

--- a/revapi-java/src/test/resources/v2/supplementary/a/C.java
+++ b/revapi-java/src/test/resources/v2/supplementary/a/C.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 package a;
-
 public class C {
     public sup.B.UsedByIgnoredClass field;
 }

--- a/revapi-java/src/test/resources/v2/supplementary/a/C.java
+++ b/revapi-java/src/test/resources/v2/supplementary/a/C.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package a;
+
 public class C {
-    public B.UsedByIgnoredClass field;
+    public sup.B.UsedByIgnoredClass field;
 }

--- a/revapi-java/src/test/resources/v2/supplementary/b/B.java
+++ b/revapi-java/src/test/resources/v2/supplementary/b/B.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package sup;
+
 public class B {
     /**
      * This changed from class to interface, but if the class C, which uses this, is ignored, we should get no

--- a/revapi-java/src/test/resources/v2/supplementary/b/D.java
+++ b/revapi-java/src/test/resources/v2/supplementary/b/D.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2014-2025 Lukas Krejci
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sup;
+public class D {
+    public sup.B.UsedByIgnoredClass field;
+}

--- a/revapi-java/src/test/resources/v2/supplementary/superType/A.java
+++ b/revapi-java/src/test/resources/v2/supplementary/superType/A.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package superType;
+
 public class A {
 
 }

--- a/revapi-java/src/test/resources/v2/supplementary/superType/B.java
+++ b/revapi-java/src/test/resources/v2/supplementary/superType/B.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package superType;
+
 public class B extends A {
     
 }


### PR DESCRIPTION
Hello!

This PR is the smallest change that we found in order to make RevAPI include the jpms [ModuleElement](https://docs.oracle.com/javase/9/docs/api/javax/lang/model/element/ModuleElement.html) as part of the AST.

With this changes, the following code returns the jpms module element for any revapi JavaModelElement whose archive includes a jpms module definition (including automatic modules). 

`ModuleElement moduleElement = element.getTypeEnvironment().getElementUtils().getModuleOf(element.getDeclaringElement());`

This allowed us to implement a revapi filter that uses the module definition in order to compute the API boundaries.

We used a multi release approach where the change only applies for java 9+ because we saw it was used for an initial java9 support. 

The test fixes are maily split packages (something that cannot be done with modules) and something at the ClasspathScanner that we think it was not triggering any issue because of the classpath setup but it becomes necessary when you use a module path.

There are for sure improvements or further additions to be made but we wanted to open the discussion.