### PR TITLE
Add getDifferenceCodePredicates to DifferenceTransform

### DIFF
--- a/revapi-basic-features/src/main/java/org/revapi/basic/SemverIgnoreTransform.java
+++ b/revapi-basic-features/src/main/java/org/revapi/basic/SemverIgnoreTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.StreamSupport;
 
@@ -61,6 +62,12 @@ public class SemverIgnoreTransform<E extends Element<E>> implements DifferenceTr
     @Override
     public Pattern[] getDifferenceCodePatterns() {
         return enabled ? new Pattern[] { Pattern.compile(".*") } : new Pattern[0];
+    }
+
+    @Nonnull
+    @Override
+    public List<Predicate<String>> getDifferenceCodePredicates() {
+        return enabled ? Collections.singletonList(__ -> true) : Collections.emptyList();
     }
 
     @Override

--- a/revapi-basic-features/src/main/java/org/revapi/basic/VersionsTransform.java
+++ b/revapi-basic-features/src/main/java/org/revapi/basic/VersionsTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +28,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -37,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -78,6 +80,11 @@ public class VersionsTransform<E extends Element<E>> extends BaseDifferenceTrans
     @Override
     public Pattern[] getDifferenceCodePatterns() {
         return enabled ? ALL_CODES : NO_CODES;
+    }
+
+    @Override
+    public List<Predicate<String>> getDifferenceCodePredicates() {
+        return enabled ? Collections.singletonList(__ -> true) : Collections.emptyList();
     }
 
     @Override

--- a/revapi-basic-features/src/main/java/org/revapi/basic/VersionsTransform.java
+++ b/revapi-basic-features/src/main/java/org/revapi/basic/VersionsTransform.java
@@ -82,6 +82,7 @@ public class VersionsTransform<E extends Element<E>> extends BaseDifferenceTrans
         return enabled ? ALL_CODES : NO_CODES;
     }
 
+    @Nonnull
     @Override
     public List<Predicate<String>> getDifferenceCodePredicates() {
         return enabled ? Collections.singletonList(__ -> true) : Collections.emptyList();

--- a/revapi-examples/difference-transform/src/main/java/org/revapi/examples/differencetransform/IssueNumberPolicyTransform.java
+++ b/revapi-examples/difference-transform/src/main/java/org/revapi/examples/differencetransform/IssueNumberPolicyTransform.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.revapi.AnalysisContext;
@@ -69,6 +70,7 @@ public class IssueNumberPolicyTransform<E extends Element<E>> extends BaseDiffer
         return new Pattern[] { Pattern.compile(".*") };
     }
 
+    @Nonnull
     @Override
     public List<Predicate<String>> getDifferenceCodePredicates() {
         // we want to react on all kinds of differences. A type of difference is identified by its "code" and we want

--- a/revapi-examples/difference-transform/src/main/java/org/revapi/examples/differencetransform/IssueNumberPolicyTransform.java
+++ b/revapi-examples/difference-transform/src/main/java/org/revapi/examples/differencetransform/IssueNumberPolicyTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,9 @@
  */
 package org.revapi.examples.differencetransform;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
@@ -64,6 +67,13 @@ public class IssueNumberPolicyTransform<E extends Element<E>> extends BaseDiffer
         // we want to react on all kinds of differences. A type of difference is identified by its "code" and we want
         // to match them all.
         return new Pattern[] { Pattern.compile(".*") };
+    }
+
+    @Override
+    public List<Predicate<String>> getDifferenceCodePredicates() {
+        // we want to react on all kinds of differences. A type of difference is identified by its "code" and we want
+        // to match them all.
+        return Collections.singletonList(__ -> true);
     }
 
     @Override

--- a/revapi-java/src/main/java/org/revapi/java/transforms/annotations/AbstractAnnotationPresenceCheck.java
+++ b/revapi-java/src/main/java/org/revapi/java/transforms/annotations/AbstractAnnotationPresenceCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,10 @@
 package org.revapi.java.transforms.annotations;
 
 import java.io.Reader;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
@@ -45,6 +48,7 @@ abstract class AbstractAnnotationPresenceCheck implements DifferenceTransform<Ja
     private final String annotationQualifiedName;
     private final Code transformedCode;
     private final Pattern[] codes;
+    private final List<Predicate<String>> predicates;
 
     protected AbstractAnnotationPresenceCheck(String annotationQualifiedName, Code annotationCheckCode,
             Code transformedCode) {
@@ -52,12 +56,19 @@ abstract class AbstractAnnotationPresenceCheck implements DifferenceTransform<Ja
         this.transformedCode = transformedCode;
         String regex = "^" + Pattern.quote(annotationCheckCode.code()) + "$";
         codes = new Pattern[] { Pattern.compile(regex) };
+        predicates = Collections.singletonList(annotationCheckCode.code()::equals);
     }
 
     @Nonnull
     @Override
     public Pattern[] getDifferenceCodePatterns() {
         return codes;
+    }
+
+    @Nonnull
+    @Override
+    public List<Predicate<String>> getDifferenceCodePredicates() {
+        return predicates;
     }
 
     @Nullable

--- a/revapi-java/src/main/java/org/revapi/java/transforms/annotations/DownplayHarmlessAnnotationChanges.java
+++ b/revapi-java/src/main/java/org/revapi/java/transforms/annotations/DownplayHarmlessAnnotationChanges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,10 +19,13 @@ package org.revapi.java.transforms.annotations;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -56,6 +59,37 @@ public final class DownplayHarmlessAnnotationChanges implements DifferenceTransf
         return new Pattern[] { exact("java.annotation.added"), exact("java.annotation.removed"),
                 exact("java.annotation.attributeValueChanged"), exact("java.annotation.attributeAdded"),
                 exact("java.annotation.attributeRemoved") };
+    }
+
+    @Nonnull
+    @Override
+    public List<Predicate<String>> getDifferenceCodePredicates() {
+        // Single Predicate that uses optimized string matching as all codes begin with the same prefix.
+        return Collections.singletonList(code -> {
+            if (code == null) {
+                return false;
+            }
+
+            // Doesn't start with the common prefix.
+            if (!code.startsWith("java.annotation.")) {
+                return false;
+            }
+
+            int length = code.length();
+            if (length == 21) {
+                return code.endsWith("added");
+            } else if (length == 23) {
+                return code.endsWith("removed");
+            } else if (length == 30) {
+                return code.endsWith("attributeAdded");
+            } else if (length == 32) {
+                return code.endsWith("attributeRemoved");
+            } else if (length == 37) {
+                return code.endsWith("attributeValueChanged");
+            }
+
+            return false;
+        });
     }
 
     @Override

--- a/revapi-java/src/main/java/org/revapi/java/transforms/methods/AnnotationTypeAttributeAdded.java
+++ b/revapi-java/src/main/java/org/revapi/java/transforms/methods/AnnotationTypeAttributeAdded.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,8 +17,11 @@
 package org.revapi.java.transforms.methods;
 
 import java.io.Reader;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
@@ -41,15 +44,23 @@ import org.revapi.java.spi.JavaMethodElement;
 public final class AnnotationTypeAttributeAdded implements DifferenceTransform<JavaMethodElement> {
     private Locale locale;
     private final Pattern[] codes;
+    private final List<Predicate<String>> predicates;
 
     public AnnotationTypeAttributeAdded() {
         codes = new Pattern[] { Pattern.compile("^" + Pattern.quote(Code.METHOD_ABSTRACT_METHOD_ADDED.code()) + "$") };
+        predicates = Collections.singletonList(Code.METHOD_ABSTRACT_METHOD_ADDED.code()::equals);
     }
 
     @Nonnull
     @Override
     public Pattern[] getDifferenceCodePatterns() {
         return codes;
+    }
+
+    @Nonnull
+    @Override
+    public List<Predicate<String>> getDifferenceCodePredicates() {
+        return predicates;
     }
 
     @Nullable

--- a/revapi-java/src/main/java/org/revapi/java/transforms/methods/AnnotationTypeAttributeRemoved.java
+++ b/revapi-java/src/main/java/org/revapi/java/transforms/methods/AnnotationTypeAttributeRemoved.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,8 +17,11 @@
 package org.revapi.java.transforms.methods;
 
 import java.io.Reader;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
@@ -40,15 +43,23 @@ import org.revapi.java.spi.JavaModelElement;
 public class AnnotationTypeAttributeRemoved implements DifferenceTransform<JavaModelElement> {
     private Locale locale;
     private final Pattern[] codes;
+    private final List<Predicate<String>> predicates;
 
     public AnnotationTypeAttributeRemoved() {
         codes = new Pattern[] { Pattern.compile("^" + Pattern.quote(Code.METHOD_REMOVED.code()) + "$") };
+        predicates = Collections.singletonList(Code.METHOD_REMOVED.code()::equals);
     }
 
     @Nonnull
     @Override
     public Pattern[] getDifferenceCodePatterns() {
         return codes;
+    }
+
+    @Nonnull
+    @Override
+    public List<Predicate<String>> getDifferenceCodePredicates() {
+        return predicates;
     }
 
     @Nullable

--- a/revapi-java/src/test/java/org/revapi/java/benchmarks/DifferenceTransformCodesBenchmark.java
+++ b/revapi-java/src/test/java/org/revapi/java/benchmarks/DifferenceTransformCodesBenchmark.java
@@ -1,5 +1,19 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+/*
+ * Copyright 2014-2023 Lukas Krejci
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.revapi.java.benchmarks;
 
 import org.junit.jupiter.api.Assertions;

--- a/revapi-java/src/test/java/org/revapi/java/benchmarks/DifferenceTransformCodesBenchmark.java
+++ b/revapi-java/src/test/java/org/revapi/java/benchmarks/DifferenceTransformCodesBenchmark.java
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package org.revapi.java.benchmarks;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import org.revapi.java.transforms.annotations.DownplayHarmlessAnnotationChanges;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+@State(Scope.Benchmark)
+public class DifferenceTransformCodesBenchmark {
+    private String code;
+
+    // Simple case where the Pattern and Predicate are effectively no-ops.
+    // Pattern.compile(".*") and ignored -> true, respectively.
+    private Pattern simplePattern;
+    private Predicate<String> simplePredicate;
+
+    // Complex case using DownplayHarmlessAnnotationChances which has multiple Patterns and complex Predicates.
+    private DownplayHarmlessAnnotationChanges complex;
+
+    @Setup
+    public void prepareDifferenceTransformCodes() {
+        this.code = "java.annotation.attributeValueChanged";
+
+        this.simplePattern = Pattern.compile(".*");
+        this.simplePredicate = __ -> true;
+
+        this.complex = new DownplayHarmlessAnnotationChanges();
+    }
+
+    @Benchmark
+    public void predicateSimple(Blackhole blackhole) {
+        blackhole.consume(simplePredicate.test(code));
+    }
+
+    @Benchmark
+    public void predicateComplex(Blackhole blackhole) {
+        for (Predicate<String> predicate : complex.getDifferenceCodePredicates()) {
+            boolean matches = predicate.test(code);
+            blackhole.consume(matches);
+            if (matches) {
+                break;
+            }
+        }
+    }
+
+    @Benchmark
+    public void patternNoop(Blackhole blackhole) {
+        blackhole.consume(simplePattern.matcher(code).matches());
+    }
+
+    @Benchmark
+    public void patternComplex(Blackhole blackhole) {
+        for (Pattern pattern : complex.getDifferenceCodePatterns()) {
+            boolean matches = pattern.matcher(code).matches();
+            blackhole.consume(matches);
+            if (matches) {
+                break;
+            }
+        }
+    }
+
+    @Test
+    public void testCodeMatching() {
+        prepareDifferenceTransformCodes();
+
+        // All cases match.
+        Assertions.assertTrue(simplePredicate.test(code));
+        Assertions.assertTrue(simplePattern.matcher(code).matches());
+
+        Assertions.assertTrue(Arrays.stream(complex.getDifferenceCodePatterns())
+            .anyMatch(pattern -> pattern.matcher(code).matches()));
+        Assertions.assertTrue(complex.getDifferenceCodePredicates().stream()
+            .anyMatch(predicate -> predicate.test(code)));
+    }
+}

--- a/revapi-java/src/test/java/org/revapi/java/benchmarks/DifferenceTransformCodesBenchmark.java
+++ b/revapi-java/src/test/java/org/revapi/java/benchmarks/DifferenceTransformCodesBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,10 @@
  */
 package org.revapi.java.benchmarks;
 
+import java.util.Arrays;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -24,10 +28,6 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.infra.Blackhole;
 import org.revapi.java.transforms.annotations.DownplayHarmlessAnnotationChanges;
-
-import java.util.Arrays;
-import java.util.function.Predicate;
-import java.util.regex.Pattern;
 
 @State(Scope.Benchmark)
 public class DifferenceTransformCodesBenchmark {
@@ -92,8 +92,8 @@ public class DifferenceTransformCodesBenchmark {
         Assertions.assertTrue(simplePattern.matcher(code).matches());
 
         Assertions.assertTrue(Arrays.stream(complex.getDifferenceCodePatterns())
-            .anyMatch(pattern -> pattern.matcher(code).matches()));
-        Assertions.assertTrue(complex.getDifferenceCodePredicates().stream()
-            .anyMatch(predicate -> predicate.test(code)));
+                .anyMatch(pattern -> pattern.matcher(code).matches()));
+        Assertions
+                .assertTrue(complex.getDifferenceCodePredicates().stream().anyMatch(predicate -> predicate.test(code)));
     }
 }

--- a/revapi-reporter-file-base/src/test/java/org/revapi/reporter/file/AbstractFileReporterTest.java
+++ b/revapi-reporter-file-base/src/test/java/org/revapi/reporter/file/AbstractFileReporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,10 +34,11 @@ import java.util.Random;
 
 import javax.annotation.Nullable;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Test;
 import org.revapi.AnalysisContext;
 import org.revapi.Report;
-import org.revapi.configuration.JSONUtil;
 
 public class AbstractFileReporterTest {
 
@@ -81,15 +82,10 @@ public class AbstractFileReporterTest {
     public void testKeepEmptyFiles() throws Exception {
         Path file = Files.createTempFile(null, null);
         try (Reporter reporter = new Reporter()) {
-            StringBuffer buf = new StringBuffer();
-            buf.append("{");
-            buf.append("\"output\": \"").append(file.toString()).append("\"");
-            buf.append(",");
-            buf.append("\"keepEmptyFile\": \"").append("false").append("\"");
-            buf.append("}");
+            ObjectNode configuration = JsonNodeFactory.instance.objectNode().put("output", file.toString())
+                    .put("keepEmptyFile", false);
 
-            reporter.initialize(
-                    AnalysisContext.builder().build().copyWithConfiguration(JSONUtil.parse(buf.toString())));
+            reporter.initialize(AnalysisContext.builder().build().copyWithConfiguration(configuration));
             reporter.report(Report.builder().build());
 
         } finally {
@@ -157,13 +153,11 @@ public class AbstractFileReporterTest {
     }
 
     private AnalysisContext ctxWithOutput(String output) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{");
+        ObjectNode configuration = JsonNodeFactory.instance.objectNode();
         if (output != null) {
-            sb.append("\"output\": \"").append(output).append("\"");
+            configuration.put("output", output);
         }
-        sb.append("}");
-        return AnalysisContext.builder().build().copyWithConfiguration(JSONUtil.parse(sb.toString()));
+        return AnalysisContext.builder().build().copyWithConfiguration(configuration);
     }
 
     static final class Reporter extends AbstractFileReporter {

--- a/revapi-reporter-json/src/test/java/org/revapi/reporter/json/JsonReporterTest.java
+++ b/revapi-reporter-json/src/test/java/org/revapi/reporter/json/JsonReporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Test;
 import org.revapi.API;
 import org.revapi.AnalysisContext;
@@ -48,15 +50,10 @@ public class JsonReporterTest {
     public void testKeepEmptyFile() throws Exception {
         Path file = Files.createTempFile(null, null);
         try (Reporter reporter = new JsonReporter()) {
-            StringBuffer buf = new StringBuffer();
-            buf.append("{");
-            buf.append("\"output\": \"").append(file.toString()).append("\"");
-            buf.append(",");
-            buf.append("\"keepEmptyFile\": \"").append("false").append("\"");
-            buf.append("}");
+            ObjectNode configuration = JsonNodeFactory.instance.objectNode().put("output", file.toString())
+                    .put("keepEmptyFile", false);
 
-            reporter.initialize(
-                    AnalysisContext.builder().build().copyWithConfiguration(JSONUtil.parse(buf.toString())));
+            reporter.initialize(AnalysisContext.builder().build().copyWithConfiguration(configuration));
             reporter.report(Report.builder().build());
 
         } finally {

--- a/revapi/src/main/java/org/revapi/DifferenceTransform.java
+++ b/revapi/src/main/java/org/revapi/DifferenceTransform.java
@@ -17,11 +17,13 @@
 package org.revapi;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.revapi.configuration.Configurable;
@@ -55,8 +57,13 @@ public interface DifferenceTransform<E extends Element<?>> extends AutoCloseable
 
     /**
      * @return The list of regexes to match the difference codes this transform can handle.
+     * @deprecated Use and implement {@link #getDifferenceCodePredicates()} instead, as it can offer better performance
+     * characteristic.
      */
-    Pattern[] getDifferenceCodePatterns();
+    @Deprecated
+    default Pattern[] getDifferenceCodePatterns() {
+        return new Pattern[] {};
+    }
 
     /**
      * Gets the list of {@link Predicate predicates} to match the difference codes this transform can handle.
@@ -64,13 +71,18 @@ public interface DifferenceTransform<E extends Element<?>> extends AutoCloseable
      * This is a replacement for {@link #getDifferenceCodePatterns()} where {@link Predicate} is more generalized and
      * allows for {@link DifferenceTransform} implementations to use more optimized solutions, such as exact string
      * matching or custom string matching rather than more performance intensive {@link Pattern}s.
+     * <p>
+     * Default implementation converts the {@link #getDifferenceCodePatterns()} {@code Pattern[]} into a {@link List} of
+     * {@link Predicate}s. Override this method to offer better performance when checking difference codes.
      *
      * @return The list of predicates to match the difference codes this transform can handle.
+     * @since 0.15.1-SNAPSHOT
      */
+    @Nonnull
     default List<Predicate<String>> getDifferenceCodePredicates() {
         Pattern[] patterns = getDifferenceCodePatterns();
         if (patterns == null) {
-            return null;
+            return Collections.emptyList();
         }
 
         List<Predicate<String>> predicates = new ArrayList<>(patterns.length);

--- a/revapi/src/main/java/org/revapi/DifferenceTransform.java
+++ b/revapi/src/main/java/org/revapi/DifferenceTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,10 @@
  */
 package org.revapi;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
@@ -54,6 +57,29 @@ public interface DifferenceTransform<E extends Element<?>> extends AutoCloseable
      * @return The list of regexes to match the difference codes this transform can handle.
      */
     Pattern[] getDifferenceCodePatterns();
+
+    /**
+     * Gets the list of {@link Predicate predicates} to match the difference codes this transform can handle.
+     * <p>
+     * This is a replacement for {@link #getDifferenceCodePatterns()} where {@link Predicate} is more generalized and
+     * allows for {@link DifferenceTransform} implementations to use more optimized solutions, such as exact string
+     * matching or custom string matching rather than more performance intensive {@link Pattern}s.
+     *
+     * @return The list of predicates to match the difference codes this transform can handle.
+     */
+    default List<Predicate<String>> getDifferenceCodePredicates() {
+        Pattern[] patterns = getDifferenceCodePatterns();
+        if (patterns == null) {
+            return null;
+        }
+
+        List<Predicate<String>> predicates = new ArrayList<>(patterns.length);
+        for (Pattern pattern : patterns) {
+            predicates.add(str -> pattern.matcher(str).matches());
+        }
+
+        return predicates;
+    }
 
     /**
      * Returns a transformed version of the difference. If this method returns null, the difference is discarded and not

--- a/revapi/src/main/java/org/revapi/DifferenceTransform.java
+++ b/revapi/src/main/java/org/revapi/DifferenceTransform.java
@@ -57,8 +57,9 @@ public interface DifferenceTransform<E extends Element<?>> extends AutoCloseable
 
     /**
      * @return The list of regexes to match the difference codes this transform can handle.
+     *
      * @deprecated Use and implement {@link #getDifferenceCodePredicates()} instead, as it can offer better performance
-     * characteristic.
+     *             characteristic.
      */
     @Deprecated
     default Pattern[] getDifferenceCodePatterns() {
@@ -76,6 +77,7 @@ public interface DifferenceTransform<E extends Element<?>> extends AutoCloseable
      * {@link Predicate}s. Override this method to offer better performance when checking difference codes.
      *
      * @return The list of predicates to match the difference codes this transform can handle.
+     *
      * @since 0.15.1-SNAPSHOT
      */
     @Nonnull

--- a/revapi/src/main/java/org/revapi/Revapi.java
+++ b/revapi/src/main/java/org/revapi/Revapi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,6 +42,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.function.BiFunction;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
@@ -714,10 +715,9 @@ public final class Revapi {
             for (List<DifferenceTransform<?>> ts : progress.transformBlocks) {
                 List<DifferenceTransform<?>> actualTs = new ArrayList<>(ts.size());
                 for (DifferenceTransform<?> t : ts) {
-                    for (Pattern p : t.getDifferenceCodePatterns()) {
-                        if (p.matcher(diff.code).matches()) {
+                    for (Predicate<String> predicate : t.getDifferenceCodePredicates()) {
+                        if (predicate.test(diff.code)) {
                             actualTs.add(t);
-
                             break;
                         }
                     }

--- a/revapi/src/main/java/org/revapi/Revapi.java
+++ b/revapi/src/main/java/org/revapi/Revapi.java
@@ -43,7 +43,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
-import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/revapi/src/main/java/org/revapi/simple/SimpleDifferenceTransform.java
+++ b/revapi/src/main/java/org/revapi/simple/SimpleDifferenceTransform.java
@@ -43,6 +43,7 @@ public abstract class SimpleDifferenceTransform<T extends Element<T>> extends Si
         return new Pattern[0];
     }
 
+    @Nonnull
     @Override
     public List<Predicate<String>> getDifferenceCodePredicates() {
         return Collections.emptyList();

--- a/revapi/src/main/java/org/revapi/simple/SimpleDifferenceTransform.java
+++ b/revapi/src/main/java/org/revapi/simple/SimpleDifferenceTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 Lukas Krejci
+ * Copyright 2014-2025 Lukas Krejci
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,9 @@
  */
 package org.revapi.simple;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
@@ -38,6 +41,11 @@ public abstract class SimpleDifferenceTransform<T extends Element<T>> extends Si
     @Override
     public @Nonnull Pattern[] getDifferenceCodePatterns() {
         return new Pattern[0];
+    }
+
+    @Override
+    public List<Predicate<String>> getDifferenceCodePredicates() {
+        return Collections.emptyList();
     }
 
     @Override


### PR DESCRIPTION
Fixes #281 

Adds `List<Predicate<String>> getDifferenceCodePredicates()` to `DifferenceTransform` in an effort to optimize difference transforms. As shown in the changes to built-in implementations of `DifferenceTransform`, many cases can be greatly optimized. 

Outside the PR I did two JMH benchmarks for two of the cases in this PR, `SemverIgnoreTransform` when enabled (effectively `ignored -> true`) and the most complex one in this PR `DownplayHarmlessAnnotationChanges` with the code being the middle pattern `java.annotation.attributeValueChanged`. The following table was the results:

| Benchmark | Mode | Count | Score | Error | Units |
| ------------ | ------- | ------ | ------ | ------ | ----- |
| SemverIgnore.pattern | average | 15 | 82.828 | +/- .574 | ns / op |
| DownplayHarmlessAnnotation.pattern | average | 15 | 141.020 | +/- 2.394 | ns / op |
| SemverIgnore.predicate | average | 15 | 0.216 | +/- .008 | ns / op |
| DownplayHarmlessAnnotation.predicate| average | 15 | 4.516 | +/- .047 | ns / op |

As this shows in the simple case the improvement is roughly 400x and the complex case is roughly 30x, and in that there is a massive reduction in allocations as well which weren't capture.